### PR TITLE
major refactor - simplify architecture and code, reduce ptr usage, le…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(OpenDrive SHARED
     src/Geometries/RoadGeometry.cpp
     src/Geometries/Spiral.cpp
     src/Geometries/Spiral/odrSpiral.cpp
+    src/Junction.cpp
     src/Lane.cpp
     src/LaneSection.cpp
     src/Mesh.cpp

--- a/README.md
+++ b/README.md
@@ -4,22 +4,22 @@ libOpenDRIVE is a **lightweight, dependency-free, fast C++ library** providing O
 It's small and can be easily integrated in other projects. It can be compiled to a **WebAssembly** library and includes JavaScript bindings. A core function is the parsing of OpenDRIVE files and the generation of 3D models. The library targets OpenDRIVE version 1.4.
 
 ## Example
-Here's an example of how code using libOpenDRIVE looks. For a complete example refer to [test.cpp](test.cpp).
+Here's an example of how code using libOpenDRIVE looks. For a more complete example refer to [test.cpp](test.cpp).
 
 ```c++
 // load map
 odr::OpenDriveMap odr_map("data.xodr");
 
 // iterate roads
-for (std::shared_ptr<odr::Road> road : odr_map.get_roads())
-    printf("road: %s, length: %.2f\n", road->id.c_str(), road->length);
+for (odr::Road road : odr_map.get_roads())
+    std::cout << "road: " << road.id << " length: " << road.length << std::endl;
 
 // get xyz point for road coordinates
-std::shared_ptr<odr::Road> odr_road = odr_map.roads.at("515");
-odr::Vec3D pt_xyz = odr_road->get_xyz(0.1 /*s*/, 1.0 /*t*/, 0.0 /*h*/);
+odr::Road odr_road = odr_map.id_to_road.at("515");
+odr::Vec3D pt_xyz = odr_road.get_xyz(0.1 /*s*/, 1.0 /*t*/, 0.0 /*h*/);
 
 // access road network attributes
-std::string lane_type = odr_road->get_lanesection(0.0)->id_to_lane.at(-1)->type;
+std::string lane_type = odr_road.get_lanesection(0.0).id_to_lane.at(-1).type;
 
 // get routing graph
 odr::RoutingGraph routing_graph = odr_map.get_routing_graph();
@@ -27,7 +27,7 @@ odr::RoutingGraph routing_graph = odr_map.get_routing_graph();
 
 
 ## Viewer
-To use the included viewer **first build the WebAssembly library** and then run a webserver in the _Viewer/_ directory (e.g. `python3 -m http.server`). Or you can test the [viewer online](https://sebastian-pagel.net/odrviewer/). 
+To use the included viewer **first build the WebAssembly library** and then run a webserver in the _Viewer/_ directory (e.g. `python3 -m http.server`). Or you can test the [viewer online](https://sebastian-pagel.net/odrviewer/index.html). 
 
 Also check out the viewer at [odrviewer.io](https://odrviewer.io) which uses this library.
 
@@ -61,10 +61,8 @@ cp ModuleOpenDrive.* ../Viewer
 ```
 
 ### Javascript Example
-Refer to the code in [main.js](Viewer/main.js) for a full example.
+Refer to the code in [main.js](Viewer/main.js) for an example.
 
 ```js
 odr_map = new Module.OpenDriveMap("./data.xodr", odr_map_config);
-const odr_road = odr_map.roads.get("515");
-const lane_type = odr_road.s_to_lanesection.get(0.0).id_to_lane.get(-1).type;
 ```

--- a/Viewer/RoadNetworkMesh.cpp
+++ b/Viewer/RoadNetworkMesh.cpp
@@ -1,23 +1,22 @@
 #include "RoadNetworkMesh.h"
-
-#include <algorithm>
+#include "Utils.hpp"
 
 namespace odr
 {
 template<typename T>
-std::vector<size_t> get_outline_indices(const std::map<size_t, T>& start_indices, const size_t num_vertices)
+std::vector<size_t> get_outline_indices(const std::map<size_t, T>& start_indices, const std::size_t num_vertices)
 {
     std::vector<size_t> out_indices;
     for (auto idx_val_iter = start_indices.begin(); idx_val_iter != start_indices.end(); idx_val_iter++)
     {
-        const size_t start_idx = idx_val_iter->first;
-        const size_t end_idx = (std::next(idx_val_iter) == start_indices.end()) ? num_vertices : std::next(idx_val_iter)->first;
-        for (size_t idx = start_idx; idx < end_idx - 2; idx += 2)
+        const std::size_t start_idx = idx_val_iter->first;
+        const std::size_t end_idx = (std::next(idx_val_iter) == start_indices.end()) ? num_vertices : std::next(idx_val_iter)->first;
+        for (std::size_t idx = start_idx; idx < end_idx - 2; idx += 2)
         {
             out_indices.push_back(idx);
             out_indices.push_back(idx + 2);
         }
-        for (size_t idx = start_idx + 1; idx < end_idx - 2; idx += 2)
+        for (std::size_t idx = start_idx + 1; idx < end_idx - 2; idx += 2)
         {
             out_indices.push_back(idx);
             out_indices.push_back(idx + 2);
@@ -31,35 +30,38 @@ std::vector<size_t> get_outline_indices(const std::map<size_t, T>& start_indices
     return out_indices;
 }
 
-std::string RoadsMesh::get_road_id(size_t vert_idx) const { return get_nearest_val<size_t, std::string>(this->road_start_indices, vert_idx); }
+std::string RoadsMesh::get_road_id(std::size_t vert_idx) const
+{
+    return get_nearest_lower_val<size_t, std::string>(this->road_start_indices, vert_idx);
+}
 
-double LanesMesh::get_lanesec_s0(size_t vert_idx) const { return get_nearest_val<size_t, double>(this->lanesec_start_indices, vert_idx); }
+double LanesMesh::get_lanesec_s0(std::size_t vert_idx) const { return get_nearest_lower_val<size_t, double>(this->lanesec_start_indices, vert_idx); }
 
-int LanesMesh::get_lane_id(size_t vert_idx) const { return get_nearest_val<size_t, int>(this->lane_start_indices, vert_idx); }
+int LanesMesh::get_lane_id(std::size_t vert_idx) const { return get_nearest_lower_val<size_t, int>(this->lane_start_indices, vert_idx); }
 
-std::array<size_t, 2> RoadsMesh::get_idx_interval_road(size_t vert_idx) const
+std::array<size_t, 2> RoadsMesh::get_idx_interval_road(std::size_t vert_idx) const
 {
     return get_key_interval<size_t, std::string>(this->road_start_indices, vert_idx, this->vertices.size());
 }
 
-std::array<size_t, 2> LanesMesh::get_idx_interval_lanesec(size_t vert_idx) const
+std::array<size_t, 2> LanesMesh::get_idx_interval_lanesec(std::size_t vert_idx) const
 {
     return get_key_interval<size_t, double>(this->lanesec_start_indices, vert_idx, this->vertices.size());
 }
 
-std::array<size_t, 2> LanesMesh::get_idx_interval_lane(size_t vert_idx) const
+std::array<size_t, 2> LanesMesh::get_idx_interval_lane(std::size_t vert_idx) const
 {
     return get_key_interval<size_t, int>(this->lane_start_indices, vert_idx, this->vertices.size());
 }
 
 std::vector<size_t> LanesMesh::get_lane_outline_indices() const { return get_outline_indices<int>(this->lane_start_indices, this->vertices.size()); }
 
-std::string RoadmarksMesh::get_roadmark_type(size_t vert_idx) const
+std::string RoadmarksMesh::get_roadmark_type(std::size_t vert_idx) const
 {
-    return get_nearest_val<size_t, std::string>(this->roadmark_type_start_indices, vert_idx);
+    return get_nearest_lower_val<size_t, std::string>(this->roadmark_type_start_indices, vert_idx);
 }
 
-std::array<size_t, 2> RoadmarksMesh::get_idx_interval_roadmark(size_t vert_idx) const
+std::array<size_t, 2> RoadmarksMesh::get_idx_interval_roadmark(std::size_t vert_idx) const
 {
     return get_key_interval<size_t, std::string>(this->roadmark_type_start_indices, vert_idx, this->vertices.size());
 }
@@ -69,12 +71,12 @@ std::vector<size_t> RoadmarksMesh::get_roadmark_outline_indices() const
     return get_outline_indices<std::string>(this->roadmark_type_start_indices, this->vertices.size());
 }
 
-std::string RoadObjectsMesh::get_road_object_id(size_t vert_idx) const
+std::string RoadObjectsMesh::get_road_object_id(std::size_t vert_idx) const
 {
-    return get_nearest_val<size_t, std::string>(this->road_object_start_indices, vert_idx);
+    return get_nearest_lower_val<size_t, std::string>(this->road_object_start_indices, vert_idx);
 }
 
-std::array<size_t, 2> RoadObjectsMesh::get_idx_interval_road_object(size_t vert_idx) const
+std::array<size_t, 2> RoadObjectsMesh::get_idx_interval_road_object(std::size_t vert_idx) const
 {
     return get_key_interval<size_t, std::string>(this->road_object_start_indices, vert_idx, this->vertices.size());
 }

--- a/Viewer/RoadNetworkMesh.h
+++ b/Viewer/RoadNetworkMesh.h
@@ -1,8 +1,7 @@
 #pragma once
-
 #include "Mesh.h"
-#include "Utils.hpp"
 
+#include <array>
 #include <map>
 #include <string>
 #include <vector>
@@ -14,11 +13,11 @@ struct RoadsMesh : public Mesh3D
     RoadsMesh() = default;
     virtual ~RoadsMesh() = default;
 
-    std::string get_road_id(size_t vert_idx) const;
+    std::string get_road_id(std::size_t vert_idx) const;
 
-    std::array<size_t, 2> get_idx_interval_road(size_t vert_idx) const;
+    std::array<size_t, 2> get_idx_interval_road(std::size_t vert_idx) const;
 
-    std::map<size_t, std::string> road_start_indices;
+    std::map<size_t, std::string> road_start_indices; // start idx of road can be used as id
 };
 
 struct LanesMesh : public RoadsMesh
@@ -26,11 +25,11 @@ struct LanesMesh : public RoadsMesh
     LanesMesh() = default;
     virtual ~LanesMesh() = default;
 
-    double get_lanesec_s0(size_t vert_idx) const;
-    int    get_lane_id(size_t vert_idx) const;
+    double get_lanesec_s0(std::size_t vert_idx) const;
+    int    get_lane_id(std::size_t vert_idx) const;
 
-    std::array<size_t, 2> get_idx_interval_lanesec(size_t vert_idx) const;
-    std::array<size_t, 2> get_idx_interval_lane(size_t vert_idx) const;
+    std::array<size_t, 2> get_idx_interval_lanesec(std::size_t vert_idx) const;
+    std::array<size_t, 2> get_idx_interval_lane(std::size_t vert_idx) const;
 
     std::vector<size_t> get_lane_outline_indices() const;
 
@@ -43,8 +42,8 @@ struct RoadmarksMesh : public LanesMesh
     RoadmarksMesh() = default;
     virtual ~RoadmarksMesh() = default;
 
-    std::string           get_roadmark_type(size_t vert_idx) const;
-    std::array<size_t, 2> get_idx_interval_roadmark(size_t vert_idx) const;
+    std::string           get_roadmark_type(std::size_t vert_idx) const;
+    std::array<size_t, 2> get_idx_interval_roadmark(std::size_t vert_idx) const;
     std::vector<size_t>   get_roadmark_outline_indices() const;
 
     std::map<size_t, std::string> roadmark_type_start_indices;
@@ -52,9 +51,9 @@ struct RoadmarksMesh : public LanesMesh
 
 struct RoadObjectsMesh : public RoadsMesh
 {
-    std::string get_road_object_id(size_t vert_idx) const;
+    std::string get_road_object_id(std::size_t vert_idx) const;
 
-    std::array<size_t, 2> get_idx_interval_road_object(size_t vert_idx) const;
+    std::array<size_t, 2> get_idx_interval_road_object(std::size_t vert_idx) const;
 
     std::map<size_t, std::string> road_object_start_indices;
 };

--- a/Viewer/ViewerUtils.cpp
+++ b/Viewer/ViewerUtils.cpp
@@ -1,9 +1,9 @@
 #include "ViewerUtils.h"
 #include "Math.hpp"
+#include "OpenDriveMap.h"
 #include "RefLine.h"
 #include "Road.h"
 
-#include <memory>
 #include <vector>
 
 namespace odr
@@ -13,18 +13,19 @@ Mesh3D get_refline_segments(const OpenDriveMap& odr_map, double eps)
 {
     /* indices are pairs of vertices representing line segments */
     Mesh3D reflines;
-    for (std::shared_ptr<const Road> road : odr_map.get_roads())
+    for (const auto& id_road : odr_map.id_to_road)
     {
-        const size_t idx_offset = reflines.vertices.size();
+        const Road&       road = id_road.second;
+        const std::size_t idx_offset = reflines.vertices.size();
 
-        std::set<double> s_vals = road->ref_line->approximate_linear(eps, 0.0, road->length);
+        std::set<double> s_vals = road.ref_line.approximate_linear(eps, 0.0, road.length);
         for (const double& s : s_vals)
         {
-            reflines.vertices.push_back(road->ref_line->get_xyz(s));
-            reflines.normals.push_back(normalize(road->ref_line->get_grad(s)));
+            reflines.vertices.push_back(road.ref_line.get_xyz(s));
+            reflines.normals.push_back(normalize(road.ref_line.get_grad(s)));
         }
 
-        for (size_t idx = idx_offset; idx < (idx_offset + s_vals.size() - 1); idx++)
+        for (std::size_t idx = idx_offset; idx < (idx_offset + s_vals.size() - 1); idx++)
         {
             reflines.indices.push_back(idx);
             reflines.indices.push_back(idx + 1);
@@ -41,39 +42,43 @@ RoadNetworkMesh get_road_network_mesh(const OpenDriveMap& odr_map, double eps)
     RoadmarksMesh&   roadmarks_mesh = out_mesh.roadmarks_mesh;
     RoadObjectsMesh& road_objects_mesh = out_mesh.road_objects_mesh;
 
-    for (std::shared_ptr<const Road> road : odr_map.get_roads())
+    for (const auto& id_road : odr_map.id_to_road)
     {
-        lanes_mesh.road_start_indices[lanes_mesh.vertices.size()] = road->id;
-        roadmarks_mesh.road_start_indices[roadmarks_mesh.vertices.size()] = road->id;
-        road_objects_mesh.road_start_indices[road_objects_mesh.vertices.size()] = road->id;
+        const Road& road = id_road.second;
+        lanes_mesh.road_start_indices[lanes_mesh.vertices.size()] = road.id;
+        roadmarks_mesh.road_start_indices[roadmarks_mesh.vertices.size()] = road.id;
+        road_objects_mesh.road_start_indices[road_objects_mesh.vertices.size()] = road.id;
 
-        for (std::shared_ptr<const LaneSection> lanesec : road->get_lanesections())
+        for (const auto& s_lanesec : road.s_to_lanesection)
         {
-            lanes_mesh.lanesec_start_indices[lanes_mesh.vertices.size()] = lanesec->s0;
-            roadmarks_mesh.lanesec_start_indices[roadmarks_mesh.vertices.size()] = lanesec->s0;
-            for (std::shared_ptr<const Lane> lane : lanesec->get_lanes())
+            const LaneSection& lanesec = s_lanesec.second;
+            lanes_mesh.lanesec_start_indices[lanes_mesh.vertices.size()] = lanesec.s0;
+            roadmarks_mesh.lanesec_start_indices[roadmarks_mesh.vertices.size()] = lanesec.s0;
+            for (const auto& id_lane : lanesec.id_to_lane)
             {
-                const size_t lanes_idx_offset = lanes_mesh.vertices.size();
-                lanes_mesh.lane_start_indices[lanes_idx_offset] = lane->id;
-                lanes_mesh.add_mesh(lane->get_mesh(lanesec->s0, lanesec->get_end(), eps));
+                const Lane&       lane = id_lane.second;
+                const std::size_t lanes_idx_offset = lanes_mesh.vertices.size();
+                lanes_mesh.lane_start_indices[lanes_idx_offset] = lane.id;
+                lanes_mesh.add_mesh(road.get_lane_mesh(lane, eps));
 
-                size_t roadmarks_idx_offset = roadmarks_mesh.vertices.size();
-                roadmarks_mesh.lane_start_indices[roadmarks_idx_offset] = lane->id;
-                const std::vector<std::shared_ptr<RoadMark>> roadmarks = lane->get_roadmarks(lanesec->s0, lanesec->get_end());
-                for (std::shared_ptr<const RoadMark> roadmark : roadmarks)
+                std::size_t roadmarks_idx_offset = roadmarks_mesh.vertices.size();
+                roadmarks_mesh.lane_start_indices[roadmarks_idx_offset] = lane.id;
+                const std::vector<RoadMark> roadmarks = lane.get_roadmarks(lanesec.s0, road.get_lanesection_end(lanesec));
+                for (const RoadMark& roadmark : roadmarks)
                 {
                     roadmarks_idx_offset = roadmarks_mesh.vertices.size();
-                    roadmarks_mesh.roadmark_type_start_indices[roadmarks_idx_offset] = roadmark->type;
-                    roadmarks_mesh.add_mesh(lane->get_roadmark_mesh(roadmark, eps));
+                    roadmarks_mesh.roadmark_type_start_indices[roadmarks_idx_offset] = roadmark.type;
+                    roadmarks_mesh.add_mesh(road.get_roadmark_mesh(lane, roadmark, eps));
                 }
             }
         }
 
-        for (std::shared_ptr<const RoadObject> road_object : road->get_road_objects())
+        for (const auto& id_road_object : road.id_to_object)
         {
-            const size_t road_objs_idx_offset = road_objects_mesh.vertices.size();
-            road_objects_mesh.road_object_start_indices[road_objs_idx_offset] = road_object->id;
-            road_objects_mesh.add_mesh(road_object->get_mesh(eps));
+            const RoadObject& road_object = id_road_object.second;
+            const std::size_t road_objs_idx_offset = road_objects_mesh.vertices.size();
+            road_objects_mesh.road_object_start_indices[road_objs_idx_offset] = road_object.id;
+            road_objects_mesh.add_mesh(road.get_road_object_mesh(road_object, eps));
         }
     }
 

--- a/Viewer/ViewerUtils.h
+++ b/Viewer/ViewerUtils.h
@@ -1,11 +1,11 @@
 #pragma once
-
 #include "Mesh.h"
-#include "OpenDriveMap.h"
 #include "RoadNetworkMesh.h"
 
 namespace odr
 {
+
+class OpenDriveMap;
 
 Mesh3D          get_refline_segments(const OpenDriveMap& odr_map, double eps);
 RoadNetworkMesh get_road_network_mesh(const OpenDriveMap& odr_map, double eps);

--- a/Viewer/main.js
+++ b/Viewer/main.js
@@ -150,7 +150,14 @@ function reloadOdrMap()
 {
     if (OpenDriveMap)
         OpenDriveMap.delete();
-    OpenDriveMap = new ModuleOpenDrive.OpenDriveMap("./data.xodr", PARAMS.lateralProfile, PARAMS.laneHeight, true, false);
+    odr_map_config = {
+        with_lateralProfile : PARAMS.lateralProfile,
+        with_laneHeight : PARAMS.laneHeight,
+        with_road_objects : false,
+        center_map : true,
+        abs_z_for_for_local_road_obj_outline : true
+    };
+    OpenDriveMap = new ModuleOpenDrive.OpenDriveMap("./data.xodr", odr_map_config);
     loadOdrMap(true, false);
 }
 
@@ -296,7 +303,6 @@ function loadOdrMap(clear_map = true, fit_view = true)
         <h3>Finished loading</h3>
         <table>
             <tr><th>Time</th><th>${((t1 - t0) / 1e3).toFixed(2)}s</th></tr>
-            <tr><th>Num Roads</th><th>${OpenDriveMap.roads.size()}</th></tr>
             <tr><th>Num Vertices</th><th>${renderer.info.render.triangles}</th></tr>
         </table>
         </div>`;
@@ -400,13 +406,12 @@ function animate()
             const road_id = odr_lanes_mesh.get_road_id(INTERSECTED_LANE_ID);
             const lanesec_s0 = odr_lanes_mesh.get_lanesec_s0(INTERSECTED_LANE_ID);
             const lane_id = odr_lanes_mesh.get_lane_id(INTERSECTED_LANE_ID);
-            const lane_type = OpenDriveMap.roads.get(road_id).s_to_lanesection.get(lanesec_s0).id_to_lane.get(lane_id).type;
             odr_lanes_mesh.delete();
             spotlight_info.innerHTML = `
                     <table>
                         <tr><th>road id</th><th>${road_id}</th></tr>
                         <tr><th>section s0</th><th>${lanesec_s0.toFixed(2)}</th></tr>
-                        <tr><th>lane</th><th>${lane_id} <span style="color:gray;">${lane_type}</span></th></tr>
+                        <tr><th>lane</th><th>${lane_id}</th></tr>
                         <tr><th>s/t</th><th>[${st_pixel_buffer[0].toFixed(2)}, ${st_pixel_buffer[1].toFixed(2)}]</th>
                         <tr><th>world</th><th>[${xyz_pixel_buffer[0].toFixed(2)}, ${xyz_pixel_buffer[1].toFixed(2)}, ${xyz_pixel_buffer[2].toFixed(2)}]</th></tr>
                     </table>`;

--- a/include/CubicBezier.hpp
+++ b/include/CubicBezier.hpp
@@ -1,17 +1,17 @@
+#pragma once
 #include "Math.hpp"
 #include "Utils.hpp"
 
 #include <array>
 #include <cmath>
 #include <map>
-#include <numeric>
 #include <set>
 #include <sstream>
-#include <stdio.h>
 
 namespace odr
 {
-template<typename T, size_t Dim>
+
+template<typename T, std::size_t Dim>
 struct CubicBezier
 {
     CubicBezier() = default;
@@ -35,13 +35,13 @@ struct CubicBezier
         std::array<Vec<T, Dim>, 4> ctrl_pts;
         ctrl_pts[0] = a;
 
-        for (size_t dim = 0; dim < Dim; dim++)
+        for (std::size_t dim = 0; dim < Dim; dim++)
             ctrl_pts[1][dim] = (b[dim] / 3) + a[dim];
 
-        for (size_t dim = 0; dim < Dim; dim++)
+        for (std::size_t dim = 0; dim < Dim; dim++)
             ctrl_pts[2][dim] = (c[dim] / 3) + 2 * ctrl_pts[1][dim] - ctrl_pts[0][dim];
 
-        for (size_t dim = 0; dim < Dim; dim++)
+        for (std::size_t dim = 0; dim < Dim; dim++)
             ctrl_pts[3][dim] = d[dim] + 3 * ctrl_pts[2][dim] - 3 * ctrl_pts[1][dim] + ctrl_pts[0][dim];
 
         return ctrl_pts;
@@ -57,13 +57,13 @@ struct CubicBezier
         std::array<Vec<T, Dim>, 4> coefficients;
         coefficients[0] = pA;
 
-        for (size_t dim = 0; dim < Dim; dim++)
+        for (std::size_t dim = 0; dim < Dim; dim++)
             coefficients[1][dim] = 3 * pB[dim] - 3 * pA[dim];
 
-        for (size_t dim = 0; dim < Dim; dim++)
+        for (std::size_t dim = 0; dim < Dim; dim++)
             coefficients[2][dim] = 3 * pC[dim] - 6 * pB[dim] + 3 * pA[dim];
 
-        for (size_t dim = 0; dim < Dim; dim++)
+        for (std::size_t dim = 0; dim < Dim; dim++)
             coefficients[3][dim] = pD[dim] - 3 * pC[dim] + 3 * pB[dim] - pA[dim];
 
         return coefficients;
@@ -76,7 +76,7 @@ struct CubicBezier
     static const double        LengthTolerance;
 };
 
-template<typename T, size_t Dim>
+template<typename T, std::size_t Dim>
 CubicBezier<T, Dim>::CubicBezier(std::array<Vec<T, Dim>, 4> control_points) : control_points(control_points)
 {
     const std::set<T> t_vals = this->approximate_linear(this->LengthTolerance);
@@ -97,24 +97,22 @@ CubicBezier<T, Dim>::CubicBezier(std::array<Vec<T, Dim>, 4> control_points) : co
     this->valid_length = std::prev(this->arclen_t.end())->first;
 }
 
-template<typename T, size_t Dim>
+template<typename T, std::size_t Dim>
 Vec<T, Dim> CubicBezier<T, Dim>::get(T t) const
 {
     Vec<T, Dim> out_pt;
-    for (size_t dim = 0; dim < Dim; dim++)
+    for (std::size_t dim = 0; dim < Dim; dim++)
         out_pt[dim] = (1 - t) * (1 - t) * (1 - t) * control_points[0][dim] + 3 * t * (1 - t) * (1 - t) * control_points[1][dim] +
                       3 * t * t * (1 - t) * control_points[2][dim] + t * t * t * control_points[3][dim];
     return out_pt;
 }
 
-template<typename T, size_t Dim>
+template<typename T, std::size_t Dim>
 T CubicBezier<T, Dim>::get_t(T arclen) const
 {
     if ((arclen - this->valid_length) > this->LengthTolerance || arclen < 0)
     {
-        std::stringstream ss_err;
-        ss_err << "arclength " << arclen << " out of range; valid length: " << this->valid_length;
-        throw std::runtime_error(ss_err.str());
+        throw std::runtime_error(string_format("arc length %.3f out of range; valid length: %.3f", arclen, this->valid_length));
     }
 
     arclen = std::min<T>(arclen, this->valid_length);
@@ -136,32 +134,32 @@ T CubicBezier<T, Dim>::get_t(T arclen) const
     return t_lower_bound + ((arclen - arcl_lower_bound) / seg_arc_len) * seg_t_len;
 }
 
-template<typename T, size_t Dim>
+template<typename T, std::size_t Dim>
 T CubicBezier<T, Dim>::get_length() const
 {
     return std::prev(arclen_t.end())->first;
 }
 
-template<typename T, size_t Dim>
+template<typename T, std::size_t Dim>
 Vec<T, Dim> CubicBezier<T, Dim>::get_grad(T t) const
 {
     std::array<Vec<T, Dim>, 4> coefficients = this->get_coefficients(this->control_points);
 
     Vec<T, Dim> grad;
-    for (size_t dim = 0; dim < Dim; dim++)
+    for (std::size_t dim = 0; dim < Dim; dim++)
         grad[dim] = coefficients[1][dim] + 2 * coefficients[2][dim] * t + 3 * coefficients[3][dim] * t * t;
 
     return grad;
 }
 
-template<typename T, size_t Dim>
+template<typename T, std::size_t Dim>
 std::array<Vec<T, Dim>, 4> CubicBezier<T, Dim>::get_subcurve(T t_start, T t_end) const
 {
     /* modified get(T t) allowing different t values for segments */
     auto f_cubic_t123 = [](const T& t1, const T& t2, const T& t3, const std::array<Vec<T, Dim>, 4>& ctrl_pts) -> Vec<T, Dim>
     {
         Vec<T, Dim> out;
-        for (size_t dim = 0; dim < Dim; dim++)
+        for (std::size_t dim = 0; dim < Dim; dim++)
         {
             out[dim] =
                 (1 - t3) *
@@ -180,7 +178,7 @@ std::array<Vec<T, Dim>, 4> CubicBezier<T, Dim>::get_subcurve(T t_start, T t_end)
     return ctrl_pts_sub;
 }
 
-template<typename T, size_t Dim>
+template<typename T, std::size_t Dim>
 std::set<T> CubicBezier<T, Dim>::approximate_linear(T eps) const
 {
     /* approximate cubic bezier by splitting into quadratic ones */
@@ -207,13 +205,13 @@ std::set<T> CubicBezier<T, Dim>::approximate_linear(T eps) const
 
         /* approximate sub-cubic bezier by two quadratic ones */
         Vec<T, Dim> pB_quad_0;
-        for (size_t dim = 0; dim < Dim; dim++)
+        for (std::size_t dim = 0; dim < Dim; dim++)
             pB_quad_0[dim] = (1.0 - 0.75) * c_pts_sub[0][dim] + 0.75 * c_pts_sub[1][dim];
         Vec<T, Dim> pB_quad_1;
-        for (size_t dim = 0; dim < Dim; dim++)
+        for (std::size_t dim = 0; dim < Dim; dim++)
             pB_quad_1[dim] = (1.0 - 0.75) * c_pts_sub[3][dim] + 0.75 * c_pts_sub[2][dim];
         Vec<T, Dim> pM_quad;
-        for (size_t dim = 0; dim < Dim; dim++)
+        for (std::size_t dim = 0; dim < Dim; dim++)
             pM_quad[dim] = (1.0 - 0.5) * pB_quad_0[dim] + 0.5 * pB_quad_1[dim];
 
         /* linear approximate the two quadratic bezier */
@@ -229,7 +227,7 @@ std::set<T> CubicBezier<T, Dim>::approximate_linear(T eps) const
     return std::set<T>(t_vals.begin(), t_vals.end());
 }
 
-template<typename T, size_t Dim>
+template<typename T, std::size_t Dim>
 const double CubicBezier<T, Dim>::LengthTolerance = 1e-2;
 
 typedef CubicBezier<double, 2> CubicBezier2D;

--- a/include/Geometries/Arc.h
+++ b/include/Geometries/Arc.h
@@ -1,17 +1,18 @@
 #pragma once
-
 #include "Math.hpp"
 #include "RoadGeometry.h"
 
 #include <memory>
+#include <set>
 
 namespace odr
 {
-class Road;
 
 struct Arc : public RoadGeometry
 {
     Arc(double s0, double x0, double y0, double hdg0, double length, double curvature);
+
+    std::unique_ptr<RoadGeometry> clone() const override;
 
     Vec2D get_xy(double s) const override;
     Vec2D get_grad(double s) const override;

--- a/include/Geometries/CubicSpline.h
+++ b/include/Geometries/CubicSpline.h
@@ -1,25 +1,22 @@
 #pragma once
-
+#include <cstddef>
 #include <map>
-#include <memory>
 #include <set>
-#include <stddef.h>
 
 namespace odr
 {
+
 struct Poly3
 {
     Poly3() = default;
     Poly3(double s0, double a, double b, double c, double d);
-    virtual ~Poly3() = default;
 
     double get(double s) const;
     double get_grad(double s) const;
     double get_max(double s_start, double s_end) const;
+    void   negate();
 
     std::set<double> approximate_linear(double eps, double s_start, double s_end) const;
-
-    void negate();
 
     double a = 0, b = 0, c = 0, d = 0;
 };
@@ -27,16 +24,14 @@ struct Poly3
 struct CubicSpline
 {
     CubicSpline() = default;
-    virtual ~CubicSpline() = default;
 
-    size_t size() const;
-    double get(double s) const;
-    double get_grad(double s) const;
-
+    std::size_t size() const;
+    double      get(double s) const;
+    double      get_grad(double s) const;
+    double      get_max(double s_start, double s_end) const;
     CubicSpline negate() const;
     CubicSpline add(const CubicSpline& other) const;
     Poly3       get_poly(double s) const;
-    double      get_max(double s_start, double s_end) const;
 
     std::set<double> approximate_linear(double eps, double s_start, double s_end) const;
 

--- a/include/Geometries/Geometries.h
+++ b/include/Geometries/Geometries.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "Arc.h"
-#include "CubicSpline.h"
-#include "Line.h"
-#include "ParamPoly3.h"
-#include "RoadGeometry.h"
-#include "Spiral.h"

--- a/include/Geometries/Line.h
+++ b/include/Geometries/Line.h
@@ -1,17 +1,18 @@
 #pragma once
-
 #include "Math.hpp"
 #include "RoadGeometry.h"
 
 #include <memory>
+#include <set>
 
 namespace odr
 {
-class Road;
 
 struct Line : public RoadGeometry
 {
     Line(double s0, double x0, double y0, double hdg0, double length);
+
+    std::unique_ptr<RoadGeometry> clone() const override;
 
     Vec2D get_xy(double s) const override;
     Vec2D get_grad(double s) const override;

--- a/include/Geometries/ParamPoly3.h
+++ b/include/Geometries/ParamPoly3.h
@@ -1,11 +1,13 @@
 #pragma once
-
 #include "CubicBezier.hpp"
+#include "Math.hpp"
 #include "RoadGeometry.h"
+
+#include <memory>
+#include <set>
 
 namespace odr
 {
-class Road;
 
 struct ParamPoly3 : public RoadGeometry
 {
@@ -24,14 +26,15 @@ struct ParamPoly3 : public RoadGeometry
                double dV,
                bool   pRange_normalized = true);
 
+    std::unique_ptr<RoadGeometry> clone() const override;
+
     Vec2D get_xy(double s) const override;
     Vec2D get_grad(double s) const override;
 
     std::set<double> approximate_linear(double eps) const override;
 
-    double aU = 0, bU = 0, cU = 0, dU = 0, aV = 0, bV = 0, cV = 0, dV = 0;
-    bool   pRange_normalized = true;
-
+    double        aU = 0, bU = 0, cU = 0, dU = 0, aV = 0, bV = 0, cV = 0, dV = 0;
+    bool          pRange_normalized = true;
     CubicBezier2D cubic_bezier;
 };
 

--- a/include/Geometries/RoadGeometry.h
+++ b/include/Geometries/RoadGeometry.h
@@ -1,7 +1,5 @@
 #pragma once
-
 #include "Math.hpp"
-#include "Utils.hpp"
 #include "XmlNode.h"
 
 #include <memory>
@@ -9,14 +7,13 @@
 
 namespace odr
 {
-class Road;
 
-enum class GeometryType
+enum GeometryType
 {
-    Line,
-    Spiral,
-    Arc,
-    ParamPoly3
+    GeometryType_Line,
+    GeometryType_Spiral,
+    GeometryType_Arc,
+    GeometryType_ParamPoly3
 };
 
 struct RoadGeometry : public XmlNode
@@ -24,21 +21,19 @@ struct RoadGeometry : public XmlNode
     RoadGeometry(double s0, double x0, double y0, double hdg0, double length, GeometryType type);
     virtual ~RoadGeometry() = default;
 
+    virtual std::unique_ptr<RoadGeometry> clone() const = 0;
+
     virtual Vec2D get_xy(double s) const = 0;
     virtual Vec2D get_grad(double s) const = 0;
 
     virtual std::set<double> approximate_linear(double eps) const = 0;
 
-    double s0 = 0;
-    double x0 = 0;
-    double y0 = 0;
-    double hdg0 = 0;
-    double length = 0;
-
+    double       s0 = 0;
+    double       x0 = 0;
+    double       y0 = 0;
+    double       hdg0 = 0;
+    double       length = 0;
     GeometryType type;
 };
-
-using ConstRoadGeometrySet = std::set<std::shared_ptr<const RoadGeometry>, SharedPtrCmp<const RoadGeometry, double, &RoadGeometry::s0>>;
-using RoadGeometrySet = std::set<std::shared_ptr<RoadGeometry>, SharedPtrCmp<RoadGeometry, double, &RoadGeometry::s0>>;
 
 } // namespace odr

--- a/include/Geometries/Spiral.h
+++ b/include/Geometries/Spiral.h
@@ -1,29 +1,35 @@
 #pragma once
-
 #include "Math.hpp"
 #include "RoadGeometry.h"
 
 #include <memory>
+#include <set>
 
 namespace odr
 {
-class Road;
 
 struct Spiral : public RoadGeometry
 {
     Spiral(double s0, double x0, double y0, double hdg0, double length, double curv_start, double curv_end);
+
+    std::unique_ptr<RoadGeometry> clone() const override;
 
     Vec2D get_xy(double s) const override;
     Vec2D get_grad(double s) const override;
 
     std::set<double> approximate_linear(double eps) const override;
 
-    double curv_start = 0, curv_end = 0;
-    double s_start = 0, s_end = 0;
+    double curv_start = 0;
+    double curv_end = 0;
+    double s_start = 0;
+    double s_end = 0;
     double c_dot = 0;
 
 private:
-    double s0_spiral = 0, x0_spiral = 0, y0_spiral = 0, a0_spiral = 0;
+    double s0_spiral = 0;
+    double x0_spiral = 0;
+    double y0_spiral = 0;
+    double a0_spiral = 0;
 };
 
 } // namespace odr

--- a/include/Junction.h
+++ b/include/Junction.h
@@ -1,61 +1,99 @@
 #pragma once
+#include "Utils.hpp"
 #include "XmlNode.h"
 
+#include <cstddef>
+#include <functional>
 #include <map>
+#include <set>
 #include <string>
-#include <vector>
 
 namespace odr
 {
 
 struct JunctionLaneLink
 {
+    JunctionLaneLink(int from, int to);
+
     int from = 0;
     int to = 0;
 };
 
+} // namespace odr
+
+template<>
+struct std::less<odr::JunctionLaneLink>
+{
+    bool operator()(const odr::JunctionLaneLink& lhs, const odr::JunctionLaneLink& rhs) const
+    {
+        return odr::compare_class_members(lhs, rhs, std::less<void>(), &odr::JunctionLaneLink::from, &odr::JunctionLaneLink::to);
+    }
+};
+
+namespace odr
+{
+
 struct JunctionConnection
 {
-    enum class ContactPoint
+    enum ContactPoint
     {
-        None,
-        Start,
-        End
+        ContactPoint_None,
+        ContactPoint_Start,
+        ContactPoint_End
     };
+
+    JunctionConnection(std::string id, std::string incoming_road, std::string connecting_road, ContactPoint contact_point);
 
     std::string  id = "";
     std::string  incoming_road = "";
     std::string  connecting_road = "";
-    ContactPoint contact_point = ContactPoint::None;
+    ContactPoint contact_point = ContactPoint_None;
 
-    std::vector<JunctionLaneLink> lane_links;
+    std::set<JunctionLaneLink> lane_links;
 };
 
 struct JunctionPriority
 {
+    JunctionPriority(std::string high, std::string low);
+
     std::string high = "";
     std::string low = "";
 };
 
-struct JunctionController
+} // namespace odr
+
+template<>
+struct std::less<odr::JunctionPriority>
 {
-    std::string id = "";
-    std::string type = "";
-    uint32_t    sequence = 0;
+    bool operator()(const odr::JunctionPriority& lhs, const odr::JunctionPriority& rhs) const
+    {
+        return odr::compare_class_members(lhs, rhs, std::less<void>(), &odr::JunctionPriority::high, &odr::JunctionPriority::low);
+    }
 };
 
-class Junction : public XmlNode, public std::enable_shared_from_this<Junction>
+namespace odr
+{
+
+struct JunctionController
+{
+    JunctionController(std::string id, std::string type, std::uint32_t sequence);
+
+    std::string   id = "";
+    std::string   type = "";
+    std::uint32_t sequence = 0;
+};
+
+class Junction : public XmlNode
 {
 public:
-    Junction() = default;
-    virtual ~Junction() = default;
+    Junction(std::string name, std::string id);
 
     std::string name = "";
     std::string id = "";
 
-    std::map<std::string, JunctionConnection> connections;
-    std::map<std::string, JunctionController> controllers;
-    std::vector<JunctionPriority>             priorities;
+    std::map<std::string, JunctionConnection> id_to_connection;
+    std::map<std::string, JunctionController> id_to_controller;
+    std::set<JunctionPriority>                priorities;
 };
 
 } // namespace odr

--- a/include/LaneSection.h
+++ b/include/LaneSection.h
@@ -1,38 +1,26 @@
 #pragma once
-
 #include "Lane.h"
-#include "Utils.hpp"
 #include "XmlNode.h"
 
 #include <map>
-#include <memory>
-#include <set>
+#include <string>
+#include <vector>
 
 namespace odr
 {
-class Road;
 
-struct LaneSection : public XmlNode, public std::enable_shared_from_this<LaneSection>
+struct LaneSection : public XmlNode
 {
-    LaneSection(double s0);
-    virtual ~LaneSection() = default;
+    LaneSection(std::string road_id, double s0);
 
-    double get_end() const;
-    double get_length() const;
+    std::vector<Lane> get_lanes() const;
 
-    ConstLaneSet get_lanes() const;
-    LaneSet      get_lanes();
+    int  get_lane_id(double s, double t) const;
+    Lane get_lane(double s, double t) const;
 
-    std::shared_ptr<const Lane> get_lane(double s, double t) const;
-    std::shared_ptr<Lane>       get_lane(double s, double t);
-
+    std::string         road_id = "";
     double              s0 = 0;
-    std::weak_ptr<Road> road;
-
-    std::map<int, std::shared_ptr<Lane>> id_to_lane;
+    std::map<int, Lane> id_to_lane;
 };
-
-using ConstLaneSectionSet = std::set<std::shared_ptr<const LaneSection>, SharedPtrCmp<const LaneSection, double, &LaneSection::s0>>;
-using LaneSectionSet = std::set<std::shared_ptr<LaneSection>, SharedPtrCmp<LaneSection, double, &LaneSection::s0>>;
 
 } // namespace odr

--- a/include/Math.hpp
+++ b/include/Math.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <algorithm>
 #include <array>
 #define _USE_MATH_DEFINES
@@ -10,7 +9,8 @@
 
 namespace odr
 {
-template<typename T, size_t Dim, typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
+
+template<typename T, std::size_t Dim, typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
 using Vec = std::array<T, Dim>;
 
 using Vec1D = Vec<double, 1>;
@@ -18,7 +18,10 @@ using Vec2D = Vec<double, 2>;
 using Vec3D = Vec<double, 3>;
 using Line3D = std::vector<Vec3D>;
 
-template<typename T, size_t Dim, typename std::enable_if_t<(Dim > 1)>* = nullptr, typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
+template<typename T,
+         std::size_t Dim,
+         typename std::enable_if_t<(Dim > 1)>* = nullptr,
+         typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
 using Mat = std::array<std::array<T, Dim>, Dim>;
 
 using Mat3D = Mat<double, 3>;
@@ -29,55 +32,55 @@ int sign(T val)
     return (T(0) < val) - (val < T(0));
 }
 
-template<typename T, size_t Dim, typename BinaryOperation, typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
+template<typename T, std::size_t Dim, typename BinaryOperation, typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
 constexpr Vec<T, Dim> operation(const Vec<T, Dim>& a, const Vec<T, Dim>& b, BinaryOperation op)
 {
     Vec<T, Dim> res{};
-    for (size_t idx = 0; idx < Dim; idx++)
+    for (std::size_t idx = 0; idx < Dim; idx++)
         res[idx] = op(a[idx], b[idx]);
     return res;
 }
 
-template<typename T, size_t Dim, typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
+template<typename T, std::size_t Dim, typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
 constexpr Vec<T, Dim> add(const Vec<T, Dim>& a, const Vec<T, Dim>& b)
 {
     return operation<T, Dim, std::plus<T>>(a, b, std::plus<T>());
 }
 
-template<typename T, size_t Dim, typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
+template<typename T, std::size_t Dim, typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
 constexpr Vec<T, Dim> sub(const Vec<T, Dim>& a, const Vec<T, Dim>& b)
 {
     return operation<T, Dim, std::minus<T>>(a, b, std::minus<T>());
 }
 
-template<typename T, size_t Dim, typename BinaryOperation, typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
+template<typename T, std::size_t Dim, typename BinaryOperation, typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
 constexpr Vec<T, Dim> operation(const T& scalar, const Vec<T, Dim>& a, BinaryOperation op)
 {
     Vec<T, Dim> res{};
-    for (size_t idx = 0; idx < Dim; idx++)
+    for (std::size_t idx = 0; idx < Dim; idx++)
         res[idx] = op(scalar, a[idx]);
     return res;
 }
 
-template<typename T, size_t Dim, typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
+template<typename T, std::size_t Dim, typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
 constexpr Vec<T, Dim> add(const T& scalar, const Vec<T, Dim>& a)
 {
     return operation<T, Dim, std::plus<T>>(scalar, a, std::plus<T>());
 }
 
-template<typename T, size_t Dim, typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
+template<typename T, std::size_t Dim, typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
 constexpr Vec<T, Dim> sub(const T& scalar, const Vec<T, Dim>& a)
 {
     return operation<T, Dim, std::minus<T>>(scalar, a, std::minus<T>());
 }
 
-template<typename T, size_t Dim, typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
+template<typename T, std::size_t Dim, typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
 constexpr Vec<T, Dim> mut(const T& scalar, const Vec<T, Dim>& a)
 {
     return operation<T, Dim, std::multiplies<T>>(scalar, a, std::multiplies<T>());
 }
 
-template<typename T, size_t Dim, typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
+template<typename T, std::size_t Dim, typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
 constexpr T euclDistance(const Vec<T, Dim> a, const Vec<T, Dim> b)
 {
     return std::sqrt(std::inner_product(a.begin(),
@@ -92,19 +95,19 @@ constexpr T euclDistance(const Vec<T, Dim> a, const Vec<T, Dim> b)
                                         }));
 }
 
-template<typename T, size_t Dim, typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
+template<typename T, std::size_t Dim, typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
 constexpr T squaredNorm(const Vec<T, Dim> v)
 {
     return std::inner_product(v.begin(), v.end(), v.begin(), T(0));
 }
 
-template<typename T, size_t Dim, typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
+template<typename T, std::size_t Dim, typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
 constexpr T norm(const Vec<T, Dim> v)
 {
     return std::sqrt(squaredNorm<T, Dim>(v));
 }
 
-template<typename T, size_t Dim, typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
+template<typename T, std::size_t Dim, typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
 constexpr Vec<T, Dim> normalize(const Vec<T, Dim> v)
 {
     Vec<T, Dim> e_v{};
@@ -119,12 +122,12 @@ constexpr Vec<T, 3> crossProduct(const Vec<T, 3> a, const Vec<T, 3> b)
     return {a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0]};
 }
 
-template<typename T, size_t Dim, typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
+template<typename T, std::size_t Dim, typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
 constexpr Vec<T, Dim> MatVecMultiplication(const Mat<T, Dim> m, const Vec<T, Dim> v)
 {
     Vec<T, Dim> res{};
     res.fill(T{0});
-    for (size_t idx = 0; idx < Dim * Dim; idx++)
+    for (std::size_t idx = 0; idx < Dim * Dim; idx++)
         res[idx / Dim] += ((double*)m.data())[idx] * v[idx % Dim];
     return res;
 }

--- a/include/Mesh.h
+++ b/include/Mesh.h
@@ -1,24 +1,23 @@
 #pragma once
-
 #include "Math.hpp"
 
-#include <string>
+#include <cstdint>
 #include <vector>
 
 namespace odr
 {
+
 struct Mesh3D
 {
     Mesh3D() = default;
-    virtual ~Mesh3D() = default;
 
     void        add_mesh(const Mesh3D& other);
     std::string get_obj() const;
 
     std::vector<Vec3D>    vertices;
     std::vector<uint32_t> indices;
-
-    std::vector<Vec3D> normals;
-    std::vector<Vec2D> st_coordinates;
+    std::vector<Vec3D>    normals;
+    std::vector<Vec2D>    st_coordinates;
 };
+
 } // namespace odr

--- a/include/OpenDriveMap.h
+++ b/include/OpenDriveMap.h
@@ -1,17 +1,16 @@
 #pragma once
+#include "Junction.h"
 #include "Road.h"
 #include "RoutingGraph.h"
 
 #include <pugixml/pugixml.hpp>
 
 #include <map>
-#include <memory>
 #include <string>
+#include <vector>
 
 namespace odr
 {
-
-class Junction;
 
 struct OpenDriveMapConfig
 {
@@ -27,20 +26,19 @@ class OpenDriveMap
 public:
     OpenDriveMap(const std::string& xodr_file, const OpenDriveMapConfig& config = OpenDriveMapConfig{});
 
-    ConstRoadSet get_roads() const;
-    RoadSet      get_roads();
+    std::vector<Road>     get_roads() const;
+    std::vector<Junction> get_junctions() const;
 
     RoutingGraph get_routing_graph() const;
 
-    const std::string  xodr_file = "";
     std::string        proj4 = "";
+    double             x_offs = 0;
+    double             y_offs = 0;
+    const std::string  xodr_file = "";
     pugi::xml_document xml_doc;
 
-    double x_offs = 0;
-    double y_offs = 0;
-
-    std::map<std::string, std::shared_ptr<Road>>     roads;
-    std::map<std::string, std::shared_ptr<Junction>> junctions;
+    std::map<std::string, Road>     id_to_road;
+    std::map<std::string, Junction> id_to_junction;
 };
 
 } // namespace odr

--- a/include/RefLine.h
+++ b/include/RefLine.h
@@ -1,5 +1,4 @@
 #pragma once
-
 #include "Geometries/CubicSpline.h"
 #include "Geometries/RoadGeometry.h"
 #include "Math.hpp"
@@ -7,31 +6,34 @@
 #include <map>
 #include <memory>
 #include <set>
+#include <string>
 
 namespace odr
 {
 
 struct RefLine
 {
-    RefLine(double length);
-    virtual ~RefLine() = default;
+    RefLine(std::string road_id, double length);
+    RefLine(const RefLine& other);
 
-    ConstRoadGeometrySet get_geometries() const;
-    RoadGeometrySet      get_geometries();
+    std::set<const RoadGeometry*> get_geometries() const;
+    std::set<RoadGeometry*>       get_geometries();
 
-    std::shared_ptr<const RoadGeometry> get_geometry(double s) const;
+    double              get_geometry_s0(double s) const;
+    const RoadGeometry* get_geometry(double s) const;
+    RoadGeometry*       get_geometry(double s);
 
-    Vec3D  get_xyz(double s) const;
-    Vec3D  get_grad(double s) const;
-    Line3D get_line(double s_start, double s_end, double eps) const;
-    double match(double x, double y) const;
-
+    Vec3D            get_xyz(double s) const;
+    Vec3D            get_grad(double s) const;
+    Line3D           get_line(double s_start, double s_end, double eps) const;
+    double           match(double x, double y) const;
     std::set<double> approximate_linear(double eps, double s_start, double s_end) const;
 
+    std::string road_id = "";
     double      length = 0;
     CubicSpline elevation_profile;
 
-    std::map<double, std::shared_ptr<RoadGeometry>> s0_to_geometry;
+    std::map<double, std::unique_ptr<RoadGeometry>> s0_to_geometry;
 };
 
 } // namespace odr

--- a/include/Road.h
+++ b/include/Road.h
@@ -1,32 +1,34 @@
 #pragma once
-
 #include "Geometries/CubicSpline.h"
 #include "LaneSection.h"
 #include "Math.hpp"
+#include "Mesh.h"
+#include "RefLine.h"
 #include "RoadObject.h"
-#include "Utils.hpp"
 #include "XmlNode.h"
 
+#include <cstddef>
 #include <map>
-#include <memory>
 #include <set>
-#include <string>
 #include <vector>
 
 namespace odr
 {
-struct RefLine;
+
+struct Lane;
+struct RoadMark;
 
 struct Crossfall : public CubicSpline
 {
     enum Side
     {
-        Both,
-        Left,
-        Right
+        Side_Both,
+        Side_Left,
+        Side_Right
     };
 
     Crossfall() = default;
+
     double get_crossfall(double s, bool on_left_side) const;
 
     std::map<double, Side> sides;
@@ -34,27 +36,32 @@ struct Crossfall : public CubicSpline
 
 struct RoadLink : public XmlNode
 {
-    enum class ContactPoint
+    enum ContactPoint
     {
-        None,
-        Start,
-        End
+        ContactPoint_None,
+        ContactPoint_Start,
+        ContactPoint_End
     };
 
-    enum class Type
+    enum Type
     {
-        None,
-        Road,
-        Junction
+        Type_None,
+        Type_Road,
+        Type_Junction
     };
+
+    RoadLink() = default;
+    RoadLink(std::string id, Type type, ContactPoint contact_point);
 
     std::string  id = "";
-    Type         type = Type::None;
-    ContactPoint contact_point = ContactPoint::None;
+    Type         type = Type_None;
+    ContactPoint contact_point = ContactPoint_None;
 };
 
 struct RoadNeighbor : public XmlNode
 {
+    RoadNeighbor(std::string id, std::string side, std::string direction);
+
     std::string id = "";
     std::string side = "";
     std::string direction = "";
@@ -62,48 +69,61 @@ struct RoadNeighbor : public XmlNode
 
 struct SpeedRecord : public XmlNode
 {
+    SpeedRecord(std::string max, std::string unit);
+
     std::string max = "";
     std::string unit = "";
 };
 
-class Road : public XmlNode, public std::enable_shared_from_this<Road>
+class Road : public XmlNode
 {
 public:
-    Road() = default;
-    virtual ~Road() = default;
+    Road(std::string id, double length, std::string junction, std::string name);
 
-    ConstLaneSectionSet get_lanesections() const;
-    LaneSectionSet      get_lanesections();
+    std::vector<LaneSection> get_lanesections() const;
+    std::vector<RoadObject>  get_road_objects() const;
 
-    ConstRoadObjectSet get_road_objects() const;
-    RoadObjectSet      get_road_objects();
+    double      get_lanesection_s0(double s) const;
+    LaneSection get_lanesection(double s) const;
 
-    std::shared_ptr<const LaneSection> get_lanesection(double s) const;
-    std::shared_ptr<LaneSection>       get_lanesection(double s);
+    double get_lanesection_end(const LaneSection& lanesection) const;
+    double get_lanesection_end(const double& lanesection_s0) const;
+    double get_lanesection_length(const LaneSection& lanesection) const;
+    double get_lanesection_length(const double& lanesection_s0) const;
 
     Vec3D get_xyz(double s, double t, double h, Vec3D* e_s = nullptr, Vec3D* e_t = nullptr, Vec3D* e_h = nullptr) const;
+    Vec3D get_surface_pt(double s, double t, Vec3D* vn = nullptr) const;
+
+    Line3D get_lane_border_line(const Lane& lane, double s_start, double s_end, double eps, bool outer = true) const;
+    Line3D get_lane_border_line(const Lane& lane, double eps, bool outer = true) const;
+
+    Mesh3D get_lane_mesh(const Lane& lane, double s_start, double s_end, double eps, std::vector<uint32_t>* outline_indices = nullptr) const;
+    Mesh3D get_lane_mesh(const Lane& lane, double eps, std::vector<uint32_t>* outline_indices = nullptr) const;
+
+    Mesh3D get_roadmark_mesh(const Lane& lane, const RoadMark& roadmark, double eps) const;
+    Mesh3D get_road_object_mesh(const RoadObject& road_object, double eps) const;
+
+    std::set<double> approximate_lane_border_linear(const Lane& lane, double s_start, double s_end, double eps, bool outer = true) const;
+    std::set<double> approximate_lane_border_linear(const Lane& lane, double eps, bool outer = true) const;
 
     double      length = 0;
-    std::string id;
-    std::string junction;
-    std::string name;
+    std::string id = "";
+    std::string junction = "";
+    std::string name = "";
 
     RoadLink                  predecessor;
     RoadLink                  successor;
     std::vector<RoadNeighbor> neighbors;
 
-    CubicSpline              lane_offset;
-    CubicSpline              superelevation;
-    Crossfall                crossfall;
-    std::shared_ptr<RefLine> ref_line;
+    CubicSpline lane_offset;
+    CubicSpline superelevation;
+    Crossfall   crossfall;
+    RefLine     ref_line;
 
-    std::map<double, std::shared_ptr<LaneSection>>     s_to_lanesection;
-    std::map<double, std::string>                      s_to_type;
-    std::map<double, SpeedRecord>                      s_to_speed;
-    std::map<std::string, std::shared_ptr<RoadObject>> id_to_object;
+    std::map<double, LaneSection>     s_to_lanesection;
+    std::map<double, std::string>     s_to_type;
+    std::map<double, SpeedRecord>     s_to_speed;
+    std::map<std::string, RoadObject> id_to_object;
 };
-
-using ConstRoadSet = std::set<std::shared_ptr<const Road>, SharedPtrCmp<const Road, std::string, &Road::id>>;
-using RoadSet = std::set<std::shared_ptr<Road>, SharedPtrCmp<Road, std::string, &Road::id>>;
 
 } // namespace odr

--- a/include/RoadMark.h
+++ b/include/RoadMark.h
@@ -1,8 +1,9 @@
 #pragma once
-
+#include "Utils.hpp"
 #include "XmlNode.h"
 
-#include <map>
+#include <functional>
+#include <set>
 #include <string>
 
 namespace odr
@@ -12,7 +13,22 @@ const double ROADMARK_WEIGHT_BOLD_WIDTH = 0.25;
 
 struct RoadMarksLine : public XmlNode
 {
-    RoadMarksLine() = default;
+    RoadMarksLine(std::string road_id,
+                  double      lanesection_s0,
+                  int         lane_id,
+                  double      group_s0,
+                  double      width,
+                  double      length,
+                  double      space,
+                  double      t_offset,
+                  double      s_offset,
+                  std::string name,
+                  std::string rule);
+
+    std::string road_id = "";
+    double      lanesection_s0 = 0;
+    int         lane_id = 0;
+    double      group_s0 = 0;
 
     double width = -1;
     double length = 0;
@@ -20,30 +36,84 @@ struct RoadMarksLine : public XmlNode
     double t_offset = 0;
     double s_offset = 0;
 
-    std::string name;
-    std::string rule;
+    std::string name = "";
+    std::string rule = "";
 };
+
+} // namespace odr
+
+template<>
+struct std::less<odr::RoadMarksLine>
+{
+    bool operator()(const odr::RoadMarksLine& lhs, const odr::RoadMarksLine& rhs) const
+    {
+        return odr::compare_class_members(lhs,
+                                          rhs,
+                                          std::less<void>(),
+                                          &odr::RoadMarksLine::road_id,
+                                          &odr::RoadMarksLine::lanesection_s0,
+                                          &odr::RoadMarksLine::lane_id,
+                                          &odr::RoadMarksLine::group_s0,
+                                          &odr::RoadMarksLine::width,
+                                          &odr::RoadMarksLine::length,
+                                          &odr::RoadMarksLine::space,
+                                          &odr::RoadMarksLine::t_offset,
+                                          &odr::RoadMarksLine::s_offset,
+                                          &odr::RoadMarksLine::name,
+                                          &odr::RoadMarksLine::rule);
+    }
+};
+
+namespace odr
+{
 
 struct RoadMarkGroup : public XmlNode
 {
-    RoadMarkGroup() = default;
+    RoadMarkGroup(std::string road_id,
+                  double      lanesection_s0,
+                  int         lane_id,
+                  double      width,
+                  double      height,
+                  double      s_offset,
+                  std::string type,
+                  std::string weight,
+                  std::string color,
+                  std::string material,
+                  std::string lane_change);
+
+    std::string road_id = "";
+    double      lanesection_s0 = 0;
+    int         lane_id = 0;
 
     double width = -1;
     double height = 0;
     double s_offset = 0;
 
-    std::string type;
-    std::string weight;
-    std::string color;
-    std::string material;
-    std::string laneChange;
+    std::string type = "";
+    std::string weight = "";
+    std::string color = "";
+    std::string material = "";
+    std::string lane_change = "";
 
-    std::map<double, RoadMarksLine> s_to_roadmarks_line;
+    std::set<RoadMarksLine> roadmark_lines;
 };
 
 struct RoadMark
 {
-    RoadMark() = default;
+    RoadMark(std::string road_id,
+             double      lanesection_s0,
+             int         lane_id,
+             double      group_s0,
+             double      s_start,
+             double      s_end,
+             double      t_offset,
+             double      width,
+             std::string type);
+
+    std::string road_id = "";
+    double      lanesection_s0 = 0;
+    int         lane_id = 0;
+    double      group_s0 = 0;
 
     double s_start = 0;
     double s_end = 0;
@@ -54,3 +124,25 @@ struct RoadMark
 };
 
 } // namespace odr
+
+template<>
+struct std::less<odr::RoadMarkGroup>
+{
+    bool operator()(const odr::RoadMarkGroup& lhs, const odr::RoadMarkGroup& rhs) const
+    {
+        return odr::compare_class_members(lhs,
+                                          rhs,
+                                          std::less<void>(),
+                                          &odr::RoadMarkGroup::road_id,
+                                          &odr::RoadMarkGroup::lanesection_s0,
+                                          &odr::RoadMarkGroup::lane_id,
+                                          &odr::RoadMarkGroup::s_offset,
+                                          &odr::RoadMarkGroup::width,
+                                          &odr::RoadMarkGroup::height,
+                                          &odr::RoadMarkGroup::type,
+                                          &odr::RoadMarkGroup::weight,
+                                          &odr::RoadMarkGroup::color,
+                                          &odr::RoadMarkGroup::material,
+                                          &odr::RoadMarkGroup::lane_change);
+    }
+};

--- a/include/RoadObject.h
+++ b/include/RoadObject.h
@@ -1,21 +1,28 @@
 #pragma once
-
 #include "Math.hpp"
 #include "Mesh.h"
-#include "Utils.hpp"
 #include "XmlNode.h"
 
-#include <memory>
-#include <set>
 #include <string>
 #include <vector>
 
 namespace odr
 {
-class Road;
 
 struct RoadObjectRepeat : public XmlNode
 {
+    RoadObjectRepeat(double s0,
+                     double length,
+                     double distance,
+                     double t_start,
+                     double t_end,
+                     double width_start,
+                     double width_end,
+                     double height_start,
+                     double height_end,
+                     double z_offset_start,
+                     double z_offset_end);
+
     double s0 = 0;
     double length = 0;
     double distance = 0;
@@ -31,36 +38,52 @@ struct RoadObjectRepeat : public XmlNode
 
 struct RoadObjectCorner : public XmlNode
 {
-    enum class Type
+    enum Type
     {
-        Local_RelZ, // z relative to road’s reference line
-        Local_AbsZ, // absolute z value
-        Road
+        Type_Local_RelZ, // z relative to road’s reference line
+        Type_Local_AbsZ, // absolute z value
+        Type_Road
     };
+
+    RoadObjectCorner(Vec3D pt, double height, Type type);
 
     Vec3D  pt;
     double height = 0;
-    Type   type = Type::Road;
+    Type   type = Type_Road;
 };
 
 struct RoadObject : public XmlNode
 {
-    RoadObject() = default;
-
-    Mesh3D get_mesh(double eps) const;
+    RoadObject(std::string road_id,
+               std::string id,
+               double      s0,
+               double      t0,
+               double      z0,
+               double      length,
+               double      valid_length,
+               double      width,
+               double      radius,
+               double      height,
+               double      hdg,
+               double      pitch,
+               double      roll,
+               std::string type,
+               std::string name,
+               std::string orientation);
 
     static Mesh3D get_cylinder(double eps, double radius, double height);
     static Mesh3D get_box(double width, double length, double height);
 
-    std::string id;
-    std::string type;
-    std::string name;
-    std::string orientation;
+    std::string road_id = "";
+
+    std::string id = "";
+    std::string type = "";
+    std::string name = "";
+    std::string orientation = "";
 
     double s0 = 0;
     double t0 = 0;
     double z0 = 0;
-
     double length = 0;
     double valid_length = 0;
     double width = 0;
@@ -71,13 +94,7 @@ struct RoadObject : public XmlNode
     double roll = 0;
 
     std::vector<RoadObjectRepeat> repeats;
-
     std::vector<RoadObjectCorner> outline;
-
-    std::weak_ptr<Road> road;
 };
-
-using ConstRoadObjectSet = std::set<std::shared_ptr<const RoadObject>, SharedPtrCmp<const RoadObject, std::string, &RoadObject::id>>;
-using RoadObjectSet = std::set<std::shared_ptr<RoadObject>, SharedPtrCmp<RoadObject, std::string, &RoadObject::id>>;
 
 } // namespace odr

--- a/src/Embind.cpp
+++ b/src/Embind.cpp
@@ -10,6 +10,7 @@
     #include "Utils.hpp"
     #include "ViewerUtils.h"
 
+    #include <cstddef>
     #include <emscripten/bind.h>
 
 namespace odr
@@ -17,13 +18,13 @@ namespace odr
 EMSCRIPTEN_BINDINGS(OpenDriveMap)
 {
     /* arrays */
-    emscripten::value_array<std::array<size_t, 2>>("array<size_t, 2>").element(emscripten::index<0>()).element(emscripten::index<1>());
+    emscripten::value_array<std::array<std::size_t, 2>>("array<std::size_t, 2>").element(emscripten::index<0>()).element(emscripten::index<1>());
     emscripten::value_array<Vec2D>("Vec2D").element(emscripten::index<0>()).element(emscripten::index<1>());
     emscripten::value_array<Vec3D>("Vec3D").element(emscripten::index<0>()).element(emscripten::index<1>()).element(emscripten::index<2>());
 
     /* vectors */
-    emscripten::register_vector<size_t>("vector<size_t>");
-    emscripten::register_vector<uint32_t>("vector<uint32_t>");
+    emscripten::register_vector<std::size_t>("vector<std::size_t>");
+    emscripten::register_vector<std::uint32_t>("vector<std::uint32_t>");
     emscripten::register_vector<int>("vector<int>");
     emscripten::register_vector<double>("vector<double>");
     emscripten::register_vector<Vec2D>("vector<Vec2D>");
@@ -34,9 +35,9 @@ EMSCRIPTEN_BINDINGS(OpenDriveMap)
     emscripten::register_vector<RoadMark>("vector<RoadMark>");
 
     /* maps */
-    emscripten::register_map<size_t, std::string>("map<size_t, string>");
-    emscripten::register_map<size_t, double>("map<size_t, double>");
-    emscripten::register_map<size_t, int>("map<size_t, int>");
+    emscripten::register_map<std::size_t, std::string>("map<std::size_t, string>");
+    emscripten::register_map<std::size_t, double>("map<std::size_t, double>");
+    emscripten::register_map<std::size_t, int>("map<std::size_t, int>");
     emscripten::register_map<int, double>("map<int, double>");
     emscripten::register_map<double, std::shared_ptr<RoadGeometry>>("map<double, shared_ptr<RoadGeometry>>");
     emscripten::register_map<std::string, std::shared_ptr<Road>>("map<string, shared_ptr<Road>>");
@@ -44,76 +45,12 @@ EMSCRIPTEN_BINDINGS(OpenDriveMap)
     emscripten::register_map<double, std::shared_ptr<LaneSection>>("map<double, shared_ptr<LaneSection>>");
 
     /* classes */
-    emscripten::class_<RoadGeometry>("RoadGeometry")
-        .smart_ptr<std::shared_ptr<RoadGeometry>>("shared_ptr<RoadGeometry>")
-        .function("get_xy", &RoadGeometry::get_xy)
-        .function("get_grad", &RoadGeometry::get_grad)
-        .property("s0", &RoadGeometry::s0);
-
-    emscripten::class_<CubicSpline>("CubicSpline")
-        .constructor<>()
-        .smart_ptr<std::shared_ptr<CubicSpline>>("shared_ptr<CubicSpline>")
-        .function("size", &CubicSpline::size)
-        .function("get", &CubicSpline::get)
-        .function("get_grad", &CubicSpline::get_grad)
-        .function("get_max", &CubicSpline::get_max);
-
-    emscripten::class_<RefLine>("RefLine")
-        .constructor<double>()
-        .smart_ptr<std::shared_ptr<RefLine>>("shared_ptr<RefLine>")
-        .function("get_xyz", &RefLine::get_xyz)
-        .function("get_grad", &RefLine::get_grad)
-        .function("get_line", &RefLine::get_line)
-        .function("match", &RefLine::match)
-        .property("length", &RefLine::length)
-        .property("elevation_profile", &RefLine::elevation_profile)
-        .property("s0_to_geometry", &RefLine::s0_to_geometry);
-
     emscripten::class_<Mesh3D>("Mesh3D")
         .function("get_obj", &Mesh3D::get_obj)
         .property("vertices", &Mesh3D::vertices)
         .property("indices", &Mesh3D::indices)
         .property("normals", &Mesh3D::normals)
         .property("st_coordinates", &Mesh3D::st_coordinates);
-
-    emscripten::class_<RoadMark>("RoadMark")
-        .property("s_start", &RoadMark::s_start)
-        .property("s_end", &RoadMark::s_end)
-        .property("t_offset", &RoadMark::t_offset)
-        .property("width", &RoadMark::width);
-
-    emscripten::class_<Lane>("Lane")
-        .constructor<int, bool, std::string>()
-        .smart_ptr<std::shared_ptr<Lane>>("shared_ptr<Lane>")
-        .function("get_surface_pt", &Lane::get_surface_pt, emscripten::allow_raw_pointers())
-        .function("get_mesh", &Lane::get_mesh, emscripten::allow_raw_pointers())
-        .function("get_roadmarks", &Lane::get_roadmarks)
-        .function("get_roadmark_mesh", &Lane::get_roadmark_mesh)
-        .property("inner_border", &Lane::inner_border)
-        .property("outer_border", &Lane::outer_border)
-        .property("id", &Lane::id)
-        .property("type", &Lane::type);
-
-    emscripten::class_<LaneSection>("LaneSection")
-        .constructor<double>()
-        .smart_ptr<std::shared_ptr<LaneSection>>("shared_ptr<LaneSection>")
-        .function("get_end", &LaneSection::get_end)
-        .function("get_lane", emscripten::select_overload<std::shared_ptr<Lane>(double, double)>(&LaneSection::get_lane))
-        .property("s0", &LaneSection::s0)
-        .property("id_to_lane", &LaneSection::id_to_lane);
-
-    emscripten::class_<Road>("Road")
-        .constructor<>()
-        .smart_ptr<std::shared_ptr<Road>>("shared_ptr<Road>")
-        .function("get_lanesection", emscripten::select_overload<std::shared_ptr<LaneSection>(double)>(&Road::get_lanesection))
-        .function("get_xyz", &Road::get_xyz, emscripten::allow_raw_pointers())
-        .property("id", &Road::id)
-        .property("junction", &Road::junction)
-        .property("length", &Road::length)
-        .property("lane_offset", &Road::lane_offset)
-        .property("lane_offset", &Road::superelevation)
-        .property("ref_line", &Road::ref_line)
-        .property("s_to_lanesection", &Road::s_to_lanesection);
 
     emscripten::class_<RoadsMesh, emscripten::base<Mesh3D>>("RoadsMesh")
         .function("get_road_id", &RoadsMesh::get_road_id)
@@ -155,7 +92,6 @@ EMSCRIPTEN_BINDINGS(OpenDriveMap)
     emscripten::class_<OpenDriveMap>("OpenDriveMap")
         .constructor<std::string, OpenDriveMapConfig>()
         .property("xodr_file", &OpenDriveMap::xodr_file)
-        .property("roads", &OpenDriveMap::roads)
         .property("x_offs", &OpenDriveMap::x_offs)
         .property("y_offs", &OpenDriveMap::y_offs);
 

--- a/src/Geometries/Arc.cpp
+++ b/src/Geometries/Arc.cpp
@@ -1,22 +1,16 @@
-#define _USE_MATH_DEFINES
-#include <cmath>
-
 #include "Geometries/Arc.h"
 #include "Geometries/RoadGeometry.h"
-#include "Math.hpp"
-#include "Utils.hpp"
 
-#include <array>
-#include <functional>
-#include <initializer_list>
-#include <vector>
+#include <cmath>
 
 namespace odr
 {
 Arc::Arc(double s0, double x0, double y0, double hdg0, double length, double curvature) :
-    RoadGeometry(s0, x0, y0, hdg0, length, GeometryType::Arc), curvature(curvature)
+    RoadGeometry(s0, x0, y0, hdg0, length, GeometryType_Arc), curvature(curvature)
 {
 }
+
+std::unique_ptr<RoadGeometry> Arc::clone() const { return std::make_unique<Arc>(*this); }
 
 Vec2D Arc::get_xy(double s) const
 {
@@ -37,8 +31,9 @@ Vec2D Arc::get_grad(double s) const
 std::set<double> Arc::approximate_linear(double eps) const
 {
     // TODO: properly implement
+    const double     s_step = 0.01 / std::abs(this->curvature); // sample at approx. every 1°
     std::set<double> s_vals;
-    for (double s = s0; s < (s0 + length); s += (10 * eps))
+    for (double s = s0; s < (s0 + length); s += s_step)
         s_vals.insert(s);
     s_vals.insert(s0 + length);
 

--- a/src/Geometries/CubicSpline.cpp
+++ b/src/Geometries/CubicSpline.cpp
@@ -1,10 +1,16 @@
 #include "Geometries/CubicSpline.h"
 #include "CubicBezier.hpp"
+#include "Math.hpp"
 #include "Utils.hpp"
 
+#include <algorithm>
+#include <array>
 #include <cmath>
+#include <iterator>
 #include <set>
+#include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -95,7 +101,7 @@ void Poly3::negate()
     d = -d;
 }
 
-size_t CubicSpline::size() const { return this->s0_to_poly.size(); }
+std::size_t CubicSpline::size() const { return this->s0_to_poly.size(); }
 
 double CubicSpline::get(double s) const
 {
@@ -119,8 +125,8 @@ CubicSpline CubicSpline::negate() const
 
 CubicSpline CubicSpline::add(const CubicSpline& other) const
 {
-    std::set<double> s0_vals = extract_keys(this->s0_to_poly);
-    std::set<double> other_s0s = extract_keys(other.s0_to_poly);
+    std::set<double> s0_vals = get_map_keys(this->s0_to_poly);
+    std::set<double> other_s0s = get_map_keys(other.s0_to_poly);
     s0_vals.insert(other_s0s.begin(), other_s0s.end());
 
     CubicSpline retval;

--- a/src/Geometries/Line.cpp
+++ b/src/Geometries/Line.cpp
@@ -1,16 +1,15 @@
 #include "Geometries/Line.h"
 #include "Geometries/RoadGeometry.h"
 #include "Math.hpp"
-#include "Utils.hpp"
 
-#include <array>
 #include <cmath>
-#include <functional>
-#include <vector>
 
 namespace odr
 {
-Line::Line(double s0, double x0, double y0, double hdg0, double length) : RoadGeometry(s0, x0, y0, hdg0, length, GeometryType::Line) {}
+
+Line::Line(double s0, double x0, double y0, double hdg0, double length) : RoadGeometry(s0, x0, y0, hdg0, length, GeometryType_Line) {}
+
+std::unique_ptr<RoadGeometry> Line::clone() const { return std::make_unique<Line>(*this); }
 
 Vec2D Line::get_xy(double s) const
 {

--- a/src/Geometries/ParamPoly3.cpp
+++ b/src/Geometries/ParamPoly3.cpp
@@ -1,14 +1,14 @@
 #include "Geometries/ParamPoly3.h"
+#include "Geometries/RoadGeometry.h"
 #include "Math.hpp"
-#include "Utils.hpp"
 
 #include <array>
 #include <cmath>
-#include <functional>
-#include <vector>
+#include <map>
 
 namespace odr
 {
+
 ParamPoly3::ParamPoly3(double s0,
                        double x0,
                        double y0,
@@ -23,7 +23,7 @@ ParamPoly3::ParamPoly3(double s0,
                        double cV,
                        double dV,
                        bool   pRange_normalized) :
-    RoadGeometry(s0, x0, y0, hdg0, length, GeometryType::ParamPoly3),
+    RoadGeometry(s0, x0, y0, hdg0, length, GeometryType_ParamPoly3),
     aU(aU), bU(bU), cU(cU), dU(dU), aV(aV), bV(bV), cV(cV), dV(dV), pRange_normalized(pRange_normalized)
 {
     if (!pRange_normalized)
@@ -42,6 +42,8 @@ ParamPoly3::ParamPoly3(double s0,
     this->cubic_bezier.arclen_t[length] = 1.0;
     this->cubic_bezier.valid_length = length;
 }
+
+std::unique_ptr<RoadGeometry> ParamPoly3::clone() const { return std::make_unique<ParamPoly3>(*this); }
 
 Vec2D ParamPoly3::get_xy(double s) const
 {

--- a/src/Geometries/RoadGeometry.cpp
+++ b/src/Geometries/RoadGeometry.cpp
@@ -1,10 +1,8 @@
 #include "Geometries/RoadGeometry.h"
 
-#include <algorithm>
-#include <cmath>
-
 namespace odr
 {
+
 RoadGeometry::RoadGeometry(double s0, double x0, double y0, double hdg0, double length, GeometryType type) :
     s0(s0), x0(x0), y0(y0), hdg0(hdg0), length(length), type(type)
 {

--- a/src/Geometries/Spiral.cpp
+++ b/src/Geometries/Spiral.cpp
@@ -1,17 +1,15 @@
 #include "Geometries/Spiral.h"
+#include "Geometries/RoadGeometry.h"
 #include "Geometries/Spiral/odrSpiral.h"
 #include "Math.hpp"
-#include "Utils.hpp"
 
-#include <array>
 #include <cmath>
-#include <functional>
-#include <vector>
 
 namespace odr
 {
+
 Spiral::Spiral(double s0, double x0, double y0, double hdg0, double length, double curv_start, double curv_end) :
-    RoadGeometry(s0, x0, y0, hdg0, length, GeometryType::Spiral), curv_start(curv_start), curv_end(curv_end)
+    RoadGeometry(s0, x0, y0, hdg0, length, GeometryType_Spiral), curv_start(curv_start), curv_end(curv_end)
 {
     this->c_dot = (curv_end - curv_start) / length;
     this->s_start = curv_start / c_dot;
@@ -20,14 +18,16 @@ Spiral::Spiral(double s0, double x0, double y0, double hdg0, double length, doub
     odrSpiral(s0_spiral, c_dot, &x0_spiral, &y0_spiral, &a0_spiral);
 }
 
+std::unique_ptr<RoadGeometry> Spiral::clone() const { return std::make_unique<Spiral>(*this); }
+
 Vec2D Spiral::get_xy(double s) const
 {
     double xs_spiral, ys_spiral, as_spiral;
     odrSpiral(s - s0 + s0_spiral, c_dot, &xs_spiral, &ys_spiral, &as_spiral);
 
-    double hdg = hdg0 - a0_spiral;
-    double xt = (std::cos(hdg) * (xs_spiral - x0_spiral)) - (std::sin(hdg) * (ys_spiral - y0_spiral)) + x0;
-    double yt = (std::sin(hdg) * (xs_spiral - x0_spiral)) + (std::cos(hdg) * (ys_spiral - y0_spiral)) + y0;
+    const double hdg = hdg0 - a0_spiral;
+    const double xt = (std::cos(hdg) * (xs_spiral - x0_spiral)) - (std::sin(hdg) * (ys_spiral - y0_spiral)) + x0;
+    const double yt = (std::sin(hdg) * (xs_spiral - x0_spiral)) + (std::cos(hdg) * (ys_spiral - y0_spiral)) + y0;
     return Vec2D{xt, yt};
 }
 

--- a/src/Junction.cpp
+++ b/src/Junction.cpp
@@ -1,0 +1,19 @@
+#include "Junction.h"
+
+namespace odr
+{
+
+JunctionLaneLink::JunctionLaneLink(int from, int to) : from(from), to(to) {}
+
+JunctionConnection::JunctionConnection(std::string id, std::string incoming_road, std::string connecting_road, ContactPoint contact_point) :
+    id(id), incoming_road(incoming_road), connecting_road(connecting_road), contact_point(contact_point)
+{
+}
+
+JunctionPriority::JunctionPriority(std::string high, std::string low) : high(high), low(low) {}
+
+JunctionController::JunctionController(std::string id, std::string type, std::uint32_t sequence) : id(id), type(type), sequence(sequence) {}
+
+Junction::Junction(std::string name, std::string id) : name(name), id(id) {}
+
+} // namespace odr

--- a/src/Lane.cpp
+++ b/src/Lane.cpp
@@ -1,243 +1,96 @@
 #include "Lane.h"
-#include "RefLine.h"
-#include "Road.h"
-#include "Utils.hpp"
+
+#include <algorithm>
+#include <iterator>
+#include <type_traits>
 
 namespace odr
 {
-Lane::Lane(int id, bool level, std::string type) : id(id), level(level), type(type) {}
 
-Vec3D Lane::get_surface_pt(double s, double t, Vec3D* vn) const
+HeightOffset::HeightOffset(double inner, double outer) : inner(inner), outer(outer) {}
+
+LaneKey::LaneKey(std::string road_id, double lanesection_s0, int lane_id) : road_id(road_id), lanesection_s0(lanesection_s0), lane_id(lane_id) {}
+
+Lane::Lane(std::string road_id, double lanesection_s0, int id, bool level, std::string type) :
+    key(road_id, lanesection_s0, id), id(id), level(level), type(type)
 {
-    auto road_ptr = this->road.lock();
-    if (!road_ptr)
-        throw std::runtime_error("could not access parent road for lane section");
-
-    const double t_inner_brdr = this->inner_border.get(s);
-    double       h_t = 0;
-
-    if (this->level)
-    {
-        const double h_inner_brdr = -std::tan(road_ptr->crossfall.get_crossfall(s, (this->id > 0))) * std::abs(t_inner_brdr);
-        const double superelev = road_ptr->superelevation.get(s); // cancel out superelevation
-        h_t = h_inner_brdr + std::tan(superelev) * (t - t_inner_brdr);
-    }
-    else
-    {
-        h_t = -std::tan(road_ptr->crossfall.get_crossfall(s, (this->id > 0))) * std::abs(t);
-    }
-
-    if (this->s_to_height_offset.size() > 0)
-    {
-        const std::map<double, HeightOffset>& height_offs = this->s_to_height_offset;
-
-        auto s0_height_offs_iter = height_offs.upper_bound(s);
-        if (s0_height_offs_iter != height_offs.begin())
-            s0_height_offs_iter--;
-
-        const double t_outer_brdr = this->outer_border.get(s);
-        const double inner_height = s0_height_offs_iter->second.inner;
-        const double outer_height = s0_height_offs_iter->second.outer;
-        const double p_t = (t_outer_brdr != t_inner_brdr) ? (t - t_inner_brdr) / (t_outer_brdr - t_inner_brdr) : 0.0;
-        h_t += p_t * (outer_height - inner_height) + inner_height;
-
-        if (std::next(s0_height_offs_iter) != height_offs.end())
-        {
-            /* if successive lane height entry available linearly interpolate */
-            const double ds = std::next(s0_height_offs_iter)->first - s0_height_offs_iter->first;
-            const double d_lh_inner = std::next(s0_height_offs_iter)->second.inner - inner_height;
-            const double dh_inner = (d_lh_inner / ds) * (s - s0_height_offs_iter->first);
-            const double d_lh_outer = std::next(s0_height_offs_iter)->second.outer - outer_height;
-            const double dh_outer = (d_lh_outer / ds) * (s - s0_height_offs_iter->first);
-
-            h_t += p_t * (dh_outer - dh_inner) + dh_inner;
-        }
-    }
-
-    return road_ptr->get_xyz(s, t, h_t, nullptr, nullptr, vn);
 }
 
-std::set<double> Lane::approximate_border_linear(double s_start, double s_end, double eps, bool outer) const
+std::vector<RoadMark> Lane::get_roadmarks(double s_start, double s_end) const
 {
-    auto road_ptr = this->road.lock();
-    if (!road_ptr)
-        throw std::runtime_error("could not access parent road for lane section");
-
-    std::set<double> s_vals = road_ptr->ref_line->approximate_linear(eps, s_start, s_end);
-
-    const CubicSpline& border = outer ? this->outer_border : this->inner_border;
-    std::set<double>   s_vals_brdr = border.approximate_linear(eps, s_start, s_end);
-    s_vals.insert(s_vals_brdr.begin(), s_vals_brdr.end());
-
-    std::set<double> s_vals_lane_height = extract_keys(this->s_to_height_offset);
-    s_vals.insert(s_vals_lane_height.begin(), s_vals_lane_height.end());
-
-    const double     t_max = this->outer_border.get_max(s_start, s_end);
-    std::set<double> s_vals_superelev = road_ptr->superelevation.approximate_linear(std::atan(eps / std::abs(t_max)), s_start, s_end);
-    s_vals.insert(s_vals_superelev.begin(), s_vals_superelev.end());
-
-    return s_vals;
-}
-
-Line3D Lane::get_border_line(double s_start, double s_end, double eps, bool outer) const
-{
-    auto road_ptr = this->road.lock();
-    if (!road_ptr)
-        throw std::runtime_error("could not access parent road for lane section");
-
-    std::set<double> s_vals = this->approximate_border_linear(s_start, s_end, eps, outer);
-
-    Line3D border_line;
-    for (const double& s : s_vals)
-    {
-        const double t = outer ? this->outer_border.get(s) : this->inner_border.get(s);
-        border_line.push_back(this->get_surface_pt(s, t));
-    }
-
-    return border_line;
-}
-
-Mesh3D Lane::get_mesh(double s_start, double s_end, double eps, std::vector<uint32_t>* outline_indices) const
-{
-    auto road_ptr = this->road.lock();
-    if (!road_ptr)
-        throw std::runtime_error("could not access parent road for lane section");
-
-    std::set<double> s_vals = road_ptr->ref_line->approximate_linear(eps, s_start, s_end);
-    std::set<double> s_vals_outer_brdr = this->outer_border.approximate_linear(eps, s_start, s_end);
-    s_vals.insert(s_vals_outer_brdr.begin(), s_vals_outer_brdr.end());
-    std::set<double> s_vals_inner_brdr = this->inner_border.approximate_linear(eps, s_start, s_end);
-    s_vals.insert(s_vals_inner_brdr.begin(), s_vals_inner_brdr.end());
-
-    std::set<double> s_vals_lane_height = extract_keys(this->s_to_height_offset);
-    s_vals.insert(s_vals_lane_height.begin(), s_vals_lane_height.end());
-
-    const double     t_max = this->outer_border.get_max(s_start, s_end);
-    std::set<double> s_vals_superelev = road_ptr->superelevation.approximate_linear(std::atan(eps / std::abs(t_max)), s_start, s_end);
-    s_vals.insert(s_vals_superelev.begin(), s_vals_superelev.end());
-
-    /* thin out s_vals array, be removing s vals closer than eps to each other */
-    for (auto s_iter = s_vals.begin(); s_iter != s_vals.end();)
-    {
-        if (std::next(s_iter) != s_vals.end() && std::next(s_iter, 2) != s_vals.end() && ((*std::next(s_iter)) - *s_iter) <= eps)
-            s_iter = std::prev(s_vals.erase(std::next(s_iter)));
-        else
-            s_iter++;
-    }
-
-    Mesh3D out_mesh;
-    for (const double& s : s_vals)
-    {
-        Vec3D        vn_inner_brdr{0, 0, 0};
-        const double t_inner_brdr = this->inner_border.get(s);
-        out_mesh.vertices.push_back(this->get_surface_pt(s, t_inner_brdr, &vn_inner_brdr));
-        out_mesh.normals.push_back(vn_inner_brdr);
-        out_mesh.st_coordinates.push_back({s, t_inner_brdr});
-
-        Vec3D        vn_outer_brdr{0, 0, 0};
-        const double t_outer_brdr = this->outer_border.get(s);
-        out_mesh.vertices.push_back(this->get_surface_pt(s, t_outer_brdr, &vn_outer_brdr));
-        out_mesh.normals.push_back(vn_outer_brdr);
-        out_mesh.st_coordinates.push_back({s, t_outer_brdr});
-    }
-
-    const size_t num_pts = out_mesh.vertices.size();
-    const bool   ccw = this->id > 0;
-    for (size_t idx = 3; idx < num_pts; idx += 2)
-    {
-        std::array<size_t, 6> indicies_patch;
-        if (ccw)
-            indicies_patch = {idx - 3, idx - 1, idx, idx - 3, idx, idx - 2};
-        else
-            indicies_patch = {idx - 3, idx, idx - 1, idx - 3, idx - 2, idx};
-        out_mesh.indices.insert(out_mesh.indices.end(), indicies_patch.begin(), indicies_patch.end());
-    }
-
-    if (outline_indices)
-    {
-        *outline_indices = get_triangle_strip_outline_indices<uint32_t>(out_mesh.vertices.size());
-    }
-
-    return out_mesh;
-}
-
-std::vector<std::shared_ptr<RoadMark>> Lane::get_roadmarks(double s_start, double s_end) const
-{
-    if ((s_start == s_end) || this->s_to_roadmark_group.empty())
+    if ((s_start == s_end) || this->roadmark_groups.empty())
         return {};
 
-    auto s_end_rm_iter = this->s_to_roadmark_group.lower_bound(s_end);
-    auto s_start_rm_iter = this->s_to_roadmark_group.upper_bound(s_start);
-    if (s_start_rm_iter != this->s_to_roadmark_group.begin())
+    auto s_start_rm_iter =
+        std::upper_bound(this->roadmark_groups.begin(),
+                         this->roadmark_groups.end(),
+                         s_start,
+                         [](const double& s, const RoadMarkGroup& rmg) -> bool { return (rmg.lanesection_s0 + rmg.s_offset) < s; });
+    if (s_start_rm_iter != this->roadmark_groups.begin())
         s_start_rm_iter--;
 
-    std::vector<std::shared_ptr<RoadMark>> roadmarks;
-    for (auto s_rm_iter = s_start_rm_iter; s_rm_iter != s_end_rm_iter; s_rm_iter++)
-    {
-        const RoadMarkGroup& roadmark_group = s_rm_iter->second;
+    auto s_end_rm_iter = std::lower_bound(this->roadmark_groups.begin(),
+                                          this->roadmark_groups.end(),
+                                          s_end,
+                                          [](const RoadMarkGroup& rmg, const double& s) -> bool { return (rmg.lanesection_s0 + rmg.s_offset) < s; });
 
-        const double s_start_roadmark_group = std::max(s_rm_iter->first, s_start);
-        const double s_end_roadmark_group = (std::next(s_rm_iter) == s_end_rm_iter) ? s_end : std::min(std::next(s_rm_iter)->first, s_end);
+    std::vector<RoadMark> roadmarks;
+    for (auto rm_group_iter = s_start_rm_iter; rm_group_iter != s_end_rm_iter; rm_group_iter++)
+    {
+        const RoadMarkGroup& roadmark_group = *rm_group_iter;
+
+        const double roadmark_group_s0 = roadmark_group.lanesection_s0 + roadmark_group.s_offset;
+        const double s_start_roadmark_group = std::max(roadmark_group_s0, s_start);
+        const double s_end_roadmark_group = (std::next(rm_group_iter) == s_end_rm_iter)
+                                                ? s_end
+                                                : std::min(std::next(rm_group_iter)->lanesection_s0 + std::next(rm_group_iter)->s_offset, s_end);
 
         double width = roadmark_group.weight == "bold" ? ROADMARK_WEIGHT_BOLD_WIDTH : ROADMARK_WEIGHT_STANDARD_WIDTH;
-        if (roadmark_group.s_to_roadmarks_line.size() == 0)
+        if (roadmark_group.roadmark_lines.empty())
         {
             if (roadmark_group.width > 0)
                 width = roadmark_group.width;
 
-            roadmarks.push_back(std::make_shared<RoadMark>(RoadMark{s_start_roadmark_group, s_end_roadmark_group, 0, width, roadmark_group.type}));
+            roadmarks.push_back(RoadMark(this->key.road_id,
+                                         this->key.lanesection_s0,
+                                         this->id,
+                                         roadmark_group_s0,
+                                         s_start_roadmark_group,
+                                         s_end_roadmark_group,
+                                         0,
+                                         width,
+                                         roadmark_group.type));
         }
         else
         {
-            for (const auto& s_roadmarks_line : roadmark_group.s_to_roadmarks_line)
+            for (const RoadMarksLine& roadmarks_line : roadmark_group.roadmark_lines)
             {
-                const RoadMarksLine& roadmarks_line = s_roadmarks_line.second;
                 if (roadmarks_line.width > 0)
                     width = roadmarks_line.width;
 
                 if ((roadmarks_line.length + roadmarks_line.space) == 0)
                     continue;
 
-                for (double s_start_single_roadmark = s_roadmarks_line.first; s_start_single_roadmark < s_end_roadmark_group;
+                const double s0_roadmarks_line = roadmarks_line.group_s0 + roadmarks_line.s_offset;
+                for (double s_start_single_roadmark = s0_roadmarks_line; s_start_single_roadmark < s_end_roadmark_group;
                      s_start_single_roadmark += (roadmarks_line.length + roadmarks_line.space))
                 {
                     const double s_end_single_roadmark = std::min(s_end, s_start_single_roadmark + roadmarks_line.length);
-                    roadmarks.push_back(std::make_shared<RoadMark>(RoadMark{
-                        s_start_single_roadmark, s_end_single_roadmark, roadmarks_line.t_offset, width, roadmark_group.type + roadmarks_line.name}));
+                    roadmarks.push_back(RoadMark(this->key.road_id,
+                                                 this->key.lanesection_s0,
+                                                 this->id,
+                                                 roadmarks_line.group_s0,
+                                                 s_start_single_roadmark,
+                                                 s_end_single_roadmark,
+                                                 roadmarks_line.t_offset,
+                                                 width,
+                                                 roadmark_group.type + roadmarks_line.name));
                 }
             }
         }
     }
 
     return roadmarks;
-}
-
-Mesh3D Lane::get_roadmark_mesh(std::shared_ptr<const RoadMark> roadmark, double eps) const
-{
-    const std::set<double> s_vals = this->approximate_border_linear(roadmark->s_start, roadmark->s_end, eps, true);
-
-    Mesh3D out_mesh;
-    for (const double& s : s_vals)
-    {
-        Vec3D        vn_edge_a{0, 0, 0};
-        const double t_edge_a = this->outer_border.get(s) + roadmark->width * 0.5 + roadmark->t_offset;
-        out_mesh.vertices.push_back(this->get_surface_pt(s, t_edge_a, &vn_edge_a));
-        out_mesh.normals.push_back(vn_edge_a);
-
-        Vec3D        vn_edge_b{0, 0, 0};
-        const double t_edge_b = t_edge_a - roadmark->width;
-        out_mesh.vertices.push_back(this->get_surface_pt(s, t_edge_b, &vn_edge_b));
-        out_mesh.normals.push_back(vn_edge_b);
-    }
-
-    const size_t num_pts = out_mesh.vertices.size();
-    for (size_t idx = 3; idx < num_pts; idx += 2)
-    {
-        std::array<size_t, 6> indicies_patch = {idx - 3, idx, idx - 1, idx - 3, idx - 2, idx};
-        out_mesh.indices.insert(out_mesh.indices.end(), indicies_patch.begin(), indicies_patch.end());
-    }
-
-    return out_mesh;
 }
 
 } // namespace odr

--- a/src/LaneSection.cpp
+++ b/src/LaneSection.cpp
@@ -1,64 +1,26 @@
 #include "LaneSection.h"
 #include "Geometries/CubicSpline.h"
-#include "Road.h"
+#include "Utils.hpp"
 
-#include <iterator>
-#include <limits>
-#include <stdexcept>
 #include <utility>
 
 namespace odr
 {
-LaneSection::LaneSection(double s0) : s0(s0) {}
+LaneSection::LaneSection(std::string road_id, double s0) : road_id(road_id), s0(s0) {}
 
-double LaneSection::get_end() const
+std::vector<Lane> LaneSection::get_lanes() const { return get_map_values(this->id_to_lane); }
+
+int LaneSection::get_lane_id(double s, double t) const
 {
-    auto road_ptr = this->road.lock();
-    if (!road_ptr)
-        throw std::runtime_error("could not access parent road for lane section");
-
-    auto s_lanesec_iter = road_ptr->s_to_lanesection.find(this->s0);
-    if (s_lanesec_iter == road_ptr->s_to_lanesection.end())
-        throw std::runtime_error("road associated with wrong lane section");
-
-    const bool   is_last = (s_lanesec_iter == std::prev(road_ptr->s_to_lanesection.end()));
-    const double next_s0 = is_last ? road_ptr->length : std::next(s_lanesec_iter)->first;
-
-    return next_s0 - std::numeric_limits<double>::min();
-}
-
-double LaneSection::get_length() const
-{
-    const double s_end = this->get_end();
-    return s_end - this->s0;
-}
-
-ConstLaneSet LaneSection::get_lanes() const
-{
-    ConstLaneSet lanes;
-    for (const auto& id_lane : this->id_to_lane)
-        lanes.insert(id_lane.second);
-
-    return lanes;
-}
-
-LaneSet LaneSection::get_lanes()
-{
-    LaneSet lanes;
-    for (const auto& id_lane : this->id_to_lane)
-        lanes.insert(id_lane.second);
-
-    return lanes;
-}
-
-std::shared_ptr<const Lane> LaneSection::get_lane(double s, double t) const
-{
-    if (this->id_to_lane.at(0)->outer_border.get(s) == t) // exactly on lane #0
-        return id_to_lane.at(0);
+    if (this->id_to_lane.at(0).outer_border.get(s) == t) // exactly on lane #0
+        return 0;
 
     std::map<double, int> outer_border_to_lane_id;
     for (const auto& id_lane : id_to_lane)
-        outer_border_to_lane_id[id_lane.second->outer_border.get(s)] = id_lane.first;
+    {
+        const double outer_brdr_t = id_lane.second.outer_border.get(s);
+        outer_border_to_lane_id.insert({outer_brdr_t, id_lane.first});
+    }
 
     auto target_iter = outer_border_to_lane_id.lower_bound(t);
     if (target_iter == outer_border_to_lane_id.end()) // past upper boundary
@@ -67,13 +29,9 @@ std::shared_ptr<const Lane> LaneSection::get_lane(double s, double t) const
     if (target_iter->second <= 0 && target_iter != outer_border_to_lane_id.begin() && t != target_iter->first)
         target_iter--;
 
-    return this->id_to_lane.at(target_iter->second);
+    return target_iter->second;
 }
 
-std::shared_ptr<Lane> LaneSection::get_lane(double s, double t)
-{
-    std::shared_ptr<Lane> lane = std::const_pointer_cast<Lane>(static_cast<const LaneSection&>(*this).get_lane(s, t));
-    return lane;
-}
+Lane LaneSection::get_lane(double s, double t) const { return this->id_to_lane.at(this->get_lane_id(s, t)); }
 
 } // namespace odr

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -1,14 +1,15 @@
 #include "Mesh.h"
-#include "Utils.hpp"
 
+#include <array>
+#include <cstddef>
 #include <sstream>
+#include <string>
 
 namespace odr
 {
 void Mesh3D::add_mesh(const Mesh3D& other)
 {
-    // CHECK((other.normals.empty() || other.normals.size() == other.vertices.size()), "#normals != #vertices");
-    const size_t idx_offset = this->vertices.size();
+    const std::size_t idx_offset = this->vertices.size();
 
     this->vertices.insert(this->vertices.end(), other.vertices.begin(), other.vertices.end());
     this->normals.insert(this->normals.end(), other.normals.begin(), other.normals.end());
@@ -30,13 +31,11 @@ std::string Mesh3D::get_obj() const
         ss_obj << "vn " << vn[0] << ' ' << vn[1] << ' ' << vn[2] << std::endl;
     }
 
-    // CHECK((this->normals.empty() || this->normals.size() == this->vertices.size()), "#normals != #vertices");
-
-    for (size_t idx = 0; idx < this->indices.size(); idx += 3)
+    for (std::size_t idx = 0; idx < this->indices.size(); idx += 3)
     {
-        const size_t i1 = indices.at(idx) + 1;
-        const size_t i2 = indices.at(idx + 1) + 1;
-        const size_t i3 = indices.at(idx + 2) + 1;
+        const std::size_t i1 = indices.at(idx) + 1;
+        const std::size_t i2 = indices.at(idx + 1) + 1;
+        const std::size_t i3 = indices.at(idx + 2) + 1;
         if (this->normals.size() == this->vertices.size())
             ss_obj << "f " << i1 << "//" << i1 << ' ' << i2 << "//" << i2 << ' ' << i3 << "//" << i3 << std::endl;
         else
@@ -45,4 +44,5 @@ std::string Mesh3D::get_obj() const
 
     return ss_obj.str();
 }
+
 } // namespace odr

--- a/src/Road.cpp
+++ b/src/Road.cpp
@@ -1,28 +1,40 @@
 #include "Road.h"
+#include "Lane.h"
 #include "RefLine.h"
+#include "RoadMark.h"
+#include "Utils.hpp"
 
+#include "earcut/earcut.hpp"
+
+#include <algorithm>
+#include <array>
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+#include <type_traits>
 #include <utility>
 
 namespace odr
 {
 double Crossfall::get_crossfall(double s, bool on_left_side) const
 {
-    const Poly3 poly = this->get_poly(s);
-
     if (this->s0_to_poly.size() > 0)
     {
         auto target_poly_iter = this->s0_to_poly.upper_bound(s);
         if (target_poly_iter != this->s0_to_poly.begin())
             target_poly_iter--;
 
-        Side side = Side::Both; // applicable side of the road
+        Side side = Side_Both; // applicable side of the road
         if (this->sides.find(target_poly_iter->first) != this->sides.end())
             side = this->sides.at(target_poly_iter->first);
 
-        if (on_left_side && side == Side::Right)
+        if (on_left_side && side == Side_Right)
             return 0;
-        else if (!on_left_side && side == Side::Left)
+        else if (!on_left_side && side == Side_Left)
             return 0;
 
         return target_poly_iter->second.get(s);
@@ -31,64 +43,74 @@ double Crossfall::get_crossfall(double s, bool on_left_side) const
     return 0;
 }
 
-ConstLaneSectionSet Road::get_lanesections() const
-{
-    ConstLaneSectionSet lanesections;
-    for (const auto& s_lansection : this->s_to_lanesection)
-        lanesections.insert(s_lansection.second);
+RoadLink::RoadLink(std::string id, Type type, ContactPoint contact_point) : id(id), type(type), contact_point(contact_point) {}
 
-    return lanesections;
+RoadNeighbor::RoadNeighbor(std::string id, std::string side, std::string direction) : id(id), side(side), direction(direction) {}
+
+SpeedRecord::SpeedRecord(std::string max, std::string unit) : max(max), unit(unit) {}
+
+std::vector<LaneSection> Road::get_lanesections() const { return get_map_values(this->s_to_lanesection); }
+
+std::vector<RoadObject> Road::get_road_objects() const { return get_map_values(this->id_to_object); }
+
+Road::Road(std::string id, double length, std::string junction, std::string name) :
+    length(length), id(id), junction(junction), name(name), ref_line(id, length)
+{
 }
 
-LaneSectionSet Road::get_lanesections()
+double Road::get_lanesection_s0(double s) const
 {
-    LaneSectionSet lanesections;
-    for (const auto& s_lansection : this->s_to_lanesection)
-        lanesections.insert(s_lansection.second);
+    if (this->s_to_lanesection.empty())
+        return NAN;
 
-    return lanesections;
+    auto s_lanesec_iter = this->s_to_lanesection.upper_bound(s);
+    if (s_lanesec_iter != this->s_to_lanesection.begin())
+        s_lanesec_iter--;
+    const LaneSection& lanesec = s_lanesec_iter->second;
+
+    if (s < lanesec.s0 || s > this->get_lanesection_end(lanesec))
+        return NAN;
+
+    return lanesec.s0;
 }
 
-ConstRoadObjectSet Road::get_road_objects() const
+LaneSection Road::get_lanesection(double s) const
 {
-    ConstRoadObjectSet road_objects;
-    for (const auto& id_obj : this->id_to_object)
-        road_objects.insert(id_obj.second);
-
-    return road_objects;
+    const double lanesec_s0 = this->get_lanesection_s0(s);
+    if (std::isnan(lanesec_s0))
+        throw std::runtime_error("no valid lanesection");
+    return this->s_to_lanesection.at(lanesec_s0);
 }
 
-RoadObjectSet Road::get_road_objects()
-{
-    RoadObjectSet road_objects;
-    for (const auto& id_obj : this->id_to_object)
-        road_objects.insert(id_obj.second);
+double Road::get_lanesection_end(const LaneSection& lanesection) const { return this->get_lanesection_end(lanesection.s0); }
 
-    return road_objects;
+double Road::get_lanesection_end(const double& lanesection_s0) const
+{
+    auto s_lanesec_iter = this->s_to_lanesection.find(lanesection_s0);
+    if (s_lanesec_iter == this->s_to_lanesection.end())
+        return NAN;
+
+    const bool   is_last = (s_lanesec_iter == std::prev(this->s_to_lanesection.end()));
+    const double next_s0 = is_last ? this->length : std::next(s_lanesec_iter)->first;
+
+    return next_s0 - std::numeric_limits<double>::min(); // should be within lane section
 }
 
-std::shared_ptr<const LaneSection> Road::get_lanesection(double s) const
+double Road::get_lanesection_length(const LaneSection& lanesection) const
 {
-    if (this->s_to_lanesection.size() > 0)
-    {
-        auto target_lane_sec_iter = this->s_to_lanesection.upper_bound(s);
-        if (target_lane_sec_iter != this->s_to_lanesection.begin())
-            target_lane_sec_iter--;
-        return target_lane_sec_iter->second;
-    }
-
-    return nullptr;
+    const double s_end = this->get_lanesection_end(lanesection);
+    return s_end - lanesection.s0;
 }
 
-std::shared_ptr<LaneSection> Road::get_lanesection(double s)
+double Road::get_lanesection_length(const double& lanesection_s0) const
 {
-    std::shared_ptr<LaneSection> lanesection = std::const_pointer_cast<LaneSection>(static_cast<const Road&>(*this).get_lanesection(s));
-    return lanesection;
+    const double s_end = this->get_lanesection_end(lanesection_s0);
+    return s_end - lanesection_s0;
 }
 
 Vec3D Road::get_xyz(double s, double t, double h, Vec3D* _e_s, Vec3D* _e_t, Vec3D* _e_h) const
 {
-    const Vec3D  s_vec = this->ref_line->get_grad(s);
+    const Vec3D  s_vec = this->ref_line.get_grad(s);
     const double theta = this->superelevation.get(s);
 
     const Vec3D e_s = normalize(s_vec);
@@ -96,7 +118,7 @@ Vec3D Road::get_xyz(double s, double t, double h, Vec3D* _e_s, Vec3D* _e_t, Vec3
                                       std::cos(theta) * e_s[0] + std::sin(theta) * -e_s[2] * e_s[1],
                                       std::sin(theta) * (e_s[0] * e_s[0] + e_s[1] * e_s[1])});
     const Vec3D e_h = normalize(crossProduct(s_vec, e_t));
-    const Vec3D p0 = this->ref_line->get_xyz(s);
+    const Vec3D p0 = this->ref_line.get_xyz(s);
     const Mat3D trans_mat{{{e_t[0], e_h[0], p0[0]}, {e_t[1], e_h[1], p0[1]}, {e_t[2], e_h[2], p0[2]}}};
 
     const Vec3D xyz = MatVecMultiplication(trans_mat, Vec3D{t, h, 1});
@@ -109,6 +131,395 @@ Vec3D Road::get_xyz(double s, double t, double h, Vec3D* _e_s, Vec3D* _e_t, Vec3
         *_e_h = e_h;
 
     return xyz;
+}
+
+Vec3D Road::get_surface_pt(double s, double t, Vec3D* vn) const
+{
+    CHECK_AND_REPAIR(s >= 0, "s < 0", s = 0);
+    CHECK_AND_REPAIR(s <= this->length, "s > Road::length", s = this->length);
+
+    const double lanesection_s0 = this->get_lanesection_s0(s);
+    if (std::isnan(lanesection_s0))
+    {
+        throw std::runtime_error(string_format("cannot get road surface pt, no lane section for s %.3f, road length: %.3f", s, this->length));
+    }
+
+    const LaneSection& lanesection = this->s_to_lanesection.at(lanesection_s0);
+    const Lane&        lane = lanesection.id_to_lane.at(lanesection.get_lane_id(s, t));
+    const double       t_inner_brdr = lane.inner_border.get(s);
+    double             h_t = 0;
+
+    if (lane.level)
+    {
+        const double h_inner_brdr = -std::tan(this->crossfall.get_crossfall(s, (lane.id > 0))) * std::abs(t_inner_brdr);
+        const double superelev = this->superelevation.get(s); // cancel out superelevation
+        h_t = h_inner_brdr + std::tan(superelev) * (t - t_inner_brdr);
+    }
+    else
+    {
+        h_t = -std::tan(this->crossfall.get_crossfall(s, (lane.id > 0))) * std::abs(t);
+    }
+
+    if (lane.s_to_height_offset.size() > 0)
+    {
+        const std::map<double, HeightOffset>& height_offs = lane.s_to_height_offset;
+
+        auto s0_height_offs_iter = height_offs.upper_bound(s);
+        if (s0_height_offs_iter != height_offs.begin())
+            s0_height_offs_iter--;
+
+        const double t_outer_brdr = lane.outer_border.get(s);
+        const double inner_height = s0_height_offs_iter->second.inner;
+        const double outer_height = s0_height_offs_iter->second.outer;
+        const double p_t = (t_outer_brdr != t_inner_brdr) ? (t - t_inner_brdr) / (t_outer_brdr - t_inner_brdr) : 0.0;
+        h_t += p_t * (outer_height - inner_height) + inner_height;
+
+        if (std::next(s0_height_offs_iter) != height_offs.end())
+        {
+            /* if successive lane height entry available linearly interpolate */
+            const double ds = std::next(s0_height_offs_iter)->first - s0_height_offs_iter->first;
+            const double d_lh_inner = std::next(s0_height_offs_iter)->second.inner - inner_height;
+            const double dh_inner = (d_lh_inner / ds) * (s - s0_height_offs_iter->first);
+            const double d_lh_outer = std::next(s0_height_offs_iter)->second.outer - outer_height;
+            const double dh_outer = (d_lh_outer / ds) * (s - s0_height_offs_iter->first);
+
+            h_t += p_t * (dh_outer - dh_inner) + dh_inner;
+        }
+    }
+
+    return this->get_xyz(s, t, h_t, nullptr, nullptr, vn);
+}
+
+std::set<double> Road::approximate_lane_border_linear(const Lane& lane, double s_start, double s_end, double eps, bool outer) const
+{
+    std::set<double> s_vals = this->ref_line.approximate_linear(eps, s_start, s_end);
+
+    const CubicSpline& border = outer ? lane.outer_border : lane.inner_border;
+    std::set<double>   s_vals_brdr = border.approximate_linear(eps, s_start, s_end);
+    s_vals.insert(s_vals_brdr.begin(), s_vals_brdr.end());
+
+    std::set<double> s_vals_lane_height = get_map_keys(lane.s_to_height_offset);
+    s_vals.insert(s_vals_lane_height.begin(), s_vals_lane_height.end());
+
+    const double     t_max = lane.outer_border.get_max(s_start, s_end);
+    std::set<double> s_vals_superelev = this->superelevation.approximate_linear(std::atan(eps / std::abs(t_max)), s_start, s_end);
+    s_vals.insert(s_vals_superelev.begin(), s_vals_superelev.end());
+
+    return s_vals;
+}
+
+std::set<double> Road::approximate_lane_border_linear(const Lane& lane, double eps, bool outer) const
+{
+    const double s_end = this->get_lanesection_end(lane.key.lanesection_s0);
+    return this->approximate_lane_border_linear(lane, lane.key.lanesection_s0, s_end, outer);
+}
+
+Line3D Road::get_lane_border_line(const Lane& lane, double s_start, double s_end, double eps, bool outer) const
+{
+    std::set<double> s_vals = this->approximate_lane_border_linear(lane, s_start, s_end, eps, outer);
+
+    Line3D border_line;
+    for (const double& s : s_vals)
+    {
+        const double t = outer ? lane.outer_border.get(s) : lane.inner_border.get(s);
+        border_line.push_back(this->get_surface_pt(s, t));
+    }
+
+    return border_line;
+}
+
+Line3D Road::get_lane_border_line(const Lane& lane, double eps, bool outer) const
+{
+    const double s_end = this->get_lanesection_end(lane.key.lanesection_s0);
+    return this->get_lane_border_line(lane, lane.key.lanesection_s0, s_end, eps, outer);
+}
+
+Mesh3D Road::get_lane_mesh(const Lane& lane, double s_start, double s_end, double eps, std::vector<uint32_t>* outline_indices) const
+{
+    std::set<double> s_vals = this->ref_line.approximate_linear(eps, s_start, s_end);
+    std::set<double> s_vals_outer_brdr = lane.outer_border.approximate_linear(eps, s_start, s_end);
+    s_vals.insert(s_vals_outer_brdr.begin(), s_vals_outer_brdr.end());
+    std::set<double> s_vals_inner_brdr = lane.inner_border.approximate_linear(eps, s_start, s_end);
+    s_vals.insert(s_vals_inner_brdr.begin(), s_vals_inner_brdr.end());
+
+    std::set<double> s_vals_lane_height = get_map_keys(lane.s_to_height_offset);
+    s_vals.insert(s_vals_lane_height.begin(), s_vals_lane_height.end());
+
+    const double     t_max = lane.outer_border.get_max(s_start, s_end);
+    std::set<double> s_vals_superelev = this->superelevation.approximate_linear(std::atan(eps / std::abs(t_max)), s_start, s_end);
+    s_vals.insert(s_vals_superelev.begin(), s_vals_superelev.end());
+
+    /* thin out s_vals array, be removing s vals closer than eps to each other */
+    for (auto s_iter = s_vals.begin(); s_iter != s_vals.end();)
+    {
+        if (std::next(s_iter) != s_vals.end() && std::next(s_iter, 2) != s_vals.end() && ((*std::next(s_iter)) - *s_iter) <= eps)
+            s_iter = std::prev(s_vals.erase(std::next(s_iter)));
+        else
+            s_iter++;
+    }
+
+    Mesh3D out_mesh;
+    for (const double& s : s_vals)
+    {
+        Vec3D        vn_inner_brdr{0, 0, 0};
+        const double t_inner_brdr = lane.inner_border.get(s);
+        out_mesh.vertices.push_back(this->get_surface_pt(s, t_inner_brdr, &vn_inner_brdr));
+        out_mesh.normals.push_back(vn_inner_brdr);
+        out_mesh.st_coordinates.push_back({s, t_inner_brdr});
+
+        Vec3D        vn_outer_brdr{0, 0, 0};
+        const double t_outer_brdr = lane.outer_border.get(s);
+        out_mesh.vertices.push_back(this->get_surface_pt(s, t_outer_brdr, &vn_outer_brdr));
+        out_mesh.normals.push_back(vn_outer_brdr);
+        out_mesh.st_coordinates.push_back({s, t_outer_brdr});
+    }
+
+    const std::size_t num_pts = out_mesh.vertices.size();
+    const bool        ccw = lane.id > 0;
+    for (std::size_t idx = 3; idx < num_pts; idx += 2)
+    {
+        std::array<size_t, 6> indicies_patch;
+        if (ccw)
+            indicies_patch = {idx - 3, idx - 1, idx, idx - 3, idx, idx - 2};
+        else
+            indicies_patch = {idx - 3, idx, idx - 1, idx - 3, idx - 2, idx};
+        out_mesh.indices.insert(out_mesh.indices.end(), indicies_patch.begin(), indicies_patch.end());
+    }
+
+    if (outline_indices)
+    {
+        *outline_indices = get_triangle_strip_outline_indices<uint32_t>(out_mesh.vertices.size());
+    }
+
+    return out_mesh;
+}
+
+Mesh3D Road::get_lane_mesh(const Lane& lane, double eps, std::vector<uint32_t>* outline_indices) const
+{
+    const double s_end = this->get_lanesection_end(lane.key.lanesection_s0);
+    return this->get_lane_mesh(lane, lane.key.lanesection_s0, s_end, eps, outline_indices);
+}
+
+Mesh3D Road::get_roadmark_mesh(const Lane& lane, const RoadMark& roadmark, double eps) const
+{
+    const std::set<double> s_vals = this->approximate_lane_border_linear(lane, roadmark.s_start, roadmark.s_end, eps, true);
+
+    Mesh3D out_mesh;
+    for (const double& s : s_vals)
+    {
+        Vec3D        vn_edge_a{0, 0, 0};
+        const double t_edge_a = lane.outer_border.get(s) + roadmark.width * 0.5 + roadmark.t_offset;
+        out_mesh.vertices.push_back(this->get_surface_pt(s, t_edge_a, &vn_edge_a));
+        out_mesh.normals.push_back(vn_edge_a);
+
+        Vec3D        vn_edge_b{0, 0, 0};
+        const double t_edge_b = t_edge_a - roadmark.width;
+        out_mesh.vertices.push_back(this->get_surface_pt(s, t_edge_b, &vn_edge_b));
+        out_mesh.normals.push_back(vn_edge_b);
+    }
+
+    const std::size_t num_pts = out_mesh.vertices.size();
+    for (std::size_t idx = 3; idx < num_pts; idx += 2)
+    {
+        std::array<size_t, 6> indicies_patch = {idx - 3, idx, idx - 1, idx - 3, idx - 2, idx};
+        out_mesh.indices.insert(out_mesh.indices.end(), indicies_patch.begin(), indicies_patch.end());
+    }
+
+    return out_mesh;
+}
+
+Mesh3D Road::get_road_object_mesh(const RoadObject& road_object, double eps) const
+{
+    std::vector<RoadObjectRepeat> repeats_copy = road_object.repeats; // make copy to keep method const
+    if (repeats_copy.empty() && road_object.outline.empty())          // handle single object as 1 object repeat
+    {
+        RoadObjectRepeat rp(NAN, 0, 1, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN);
+        rp.xml_node = this->xml_node;
+        repeats_copy.push_back(rp);
+    }
+
+    const Mat3D rot_mat = EulerAnglesToMatrix<double>(road_object.roll, road_object.pitch, road_object.hdg);
+
+    /* helper functions - object repeat's attributes override object's attributes */
+    auto get_t_s = [&](const RoadObjectRepeat& r, const double& p) -> double
+    { return (std::isnan(r.t_start) || std::isnan(r.t_end)) ? road_object.t0 : r.t_start + p * (r.t_end - r.t_start); };
+
+    auto get_z_s = [&](const RoadObjectRepeat& r, const double& p) -> double
+    {
+        return (std::isnan(r.z_offset_start) || std::isnan(r.z_offset_end)) ? road_object.z0
+                                                                            : r.z_offset_start + p * (r.z_offset_end - r.z_offset_start);
+    };
+
+    auto get_height_s = [&](const RoadObjectRepeat& r, const double& p) -> double
+    { return (std::isnan(r.height_start) || std::isnan(r.height_end)) ? road_object.height : r.height_start + p * (r.height_end - r.height_start); };
+
+    auto get_width_s = [&](const RoadObjectRepeat& r, const double& p) -> double
+    { return (std::isnan(r.width_start) || std::isnan(r.width_end)) ? road_object.width : r.width_start + p * (r.width_end - r.width_start); };
+
+    Mesh3D road_obj_mesh;
+
+    for (const RoadObjectRepeat& repeat : repeats_copy)
+    {
+        const double s_start = std::isnan(repeat.s0) ? road_object.s0 : repeat.s0;
+        const double s_end = std::min(s_start + repeat.length, this->length);
+
+        if (repeat.distance != 0)
+        {
+            for (double s = s_start; s <= s_end; s += repeat.distance)
+            {
+                const double p = (s_end == s_start) ? 1.0 : (s - s_start) / (s_end - s_start);
+                const double t_s = get_t_s(repeat, p);
+                const double z_s = get_z_s(repeat, p);
+                const double height_s = get_height_s(repeat, p);
+                const double w_s = get_width_s(repeat, p);
+
+                Mesh3D single_road_obj_mesh;
+                if (road_object.radius > 0)
+                {
+                    single_road_obj_mesh = road_object.get_cylinder(eps, road_object.radius, height_s);
+                }
+                else if (w_s > 0 && road_object.length > 0)
+                {
+                    single_road_obj_mesh = road_object.get_box(w_s, road_object.length, height_s);
+                }
+
+                Vec3D       e_s, e_t, e_h;
+                const Vec3D p0 = this->get_xyz(s, t_s, z_s, &e_s, &e_t, &e_h);
+                const Mat3D base_mat{{{e_s[0], e_t[0], e_h[0]}, {e_s[1], e_t[1], e_h[1]}, {e_s[2], e_t[2], e_h[2]}}};
+                for (Vec3D& pt_uvz : single_road_obj_mesh.vertices)
+                {
+                    pt_uvz = MatVecMultiplication(rot_mat, pt_uvz);
+                    pt_uvz = MatVecMultiplication(base_mat, pt_uvz);
+                    pt_uvz = add(pt_uvz, p0);
+
+                    single_road_obj_mesh.st_coordinates.push_back({s, t_s});
+                }
+
+                road_obj_mesh.add_mesh(single_road_obj_mesh);
+            }
+        }
+        else
+        {
+            Mesh3D continuous_road_obj_mesh;
+
+            const std::array<size_t, 24> idx_patch_template = {1, 5, 4, 1, 4, 0, 2, 7, 6, 2, 3, 7, 1, 6, 5, 1, 2, 6, 0, 4, 7, 0, 7, 3};
+            for (const double& s : this->ref_line.approximate_linear(eps, s_start, s_end))
+            {
+                const double p = (s_end == s_start) ? 1.0 : (s - s_start) / (s_end - s_start);
+                const double t_s = get_t_s(repeat, p);
+                const double z_s = get_z_s(repeat, p);
+                const double height_s = get_height_s(repeat, p);
+                const double w_s = get_width_s(repeat, p);
+
+                continuous_road_obj_mesh.vertices.push_back(this->get_xyz(s, t_s - 0.5 * w_s, z_s));
+                continuous_road_obj_mesh.vertices.push_back(this->get_xyz(s, t_s + 0.5 * w_s, z_s));
+                continuous_road_obj_mesh.vertices.push_back(this->get_xyz(s, t_s + 0.5 * w_s, z_s + height_s));
+                continuous_road_obj_mesh.vertices.push_back(this->get_xyz(s, t_s - 0.5 * w_s, z_s + height_s));
+
+                const std::array<Vec2D, 4> s_t_coords = {{{s, t_s - 0.5 * w_s}, {s, t_s + 0.5 * w_s}, {s, t_s + 0.5 * w_s}, {s, t_s - 0.5 * w_s}}};
+                continuous_road_obj_mesh.st_coordinates.insert(continuous_road_obj_mesh.st_coordinates.end(), s_t_coords.begin(), s_t_coords.end());
+
+                if (continuous_road_obj_mesh.vertices.size() == 4)
+                {
+                    const std::array<size_t, 6> front_idx_patch = {0, 2, 1, 0, 3, 2};
+                    continuous_road_obj_mesh.indices.insert(continuous_road_obj_mesh.indices.end(), front_idx_patch.begin(), front_idx_patch.end());
+                }
+
+                if (continuous_road_obj_mesh.vertices.size() > 7)
+                {
+                    const std::size_t      cur_offs = continuous_road_obj_mesh.vertices.size() - 8;
+                    std::array<size_t, 24> wall_idx_patch;
+                    for (std::size_t idx = 0; idx < idx_patch_template.size(); idx++)
+                        wall_idx_patch.at(idx) = idx_patch_template.at(idx) + cur_offs;
+                    continuous_road_obj_mesh.indices.insert(continuous_road_obj_mesh.indices.end(), wall_idx_patch.begin(), wall_idx_patch.end());
+                }
+            }
+
+            const std::size_t           last_idx = continuous_road_obj_mesh.vertices.size() - 1;
+            const std::array<size_t, 6> back_idx_patch = {last_idx - 3, last_idx - 2, last_idx - 1, last_idx - 3, last_idx - 1, last_idx};
+            continuous_road_obj_mesh.indices.insert(continuous_road_obj_mesh.indices.end(), back_idx_patch.begin(), back_idx_patch.end());
+
+            road_obj_mesh.add_mesh(continuous_road_obj_mesh);
+        }
+    }
+
+    if (road_object.outline.size() > 1)
+    {
+        Vec3D       e_s, e_t, e_h;
+        const Vec3D p0 = this->get_xyz(road_object.s0, road_object.t0, road_object.z0, &e_s, &e_t, &e_h);
+
+        const Mat3D base_mat{{{e_s[0], e_t[0], e_h[0]}, {e_s[1], e_t[1], e_h[1]}, {e_s[2], e_t[2], e_h[2]}}};
+
+        Mesh3D outline_road_obj_mesh;
+
+        /* add top outline first - ensure the top vertices are at the front */
+        const bool is_flat_object =
+            std::all_of(road_object.outline.begin(), road_object.outline.end(), [](const RoadObjectCorner& c) { return c.height == 0; });
+        if (!is_flat_object)
+        {
+            for (const RoadObjectCorner& corner : road_object.outline)
+            {
+                Vec3D pt_top;
+                if (corner.type == RoadObjectCorner::Type_Local_AbsZ || corner.type == RoadObjectCorner::Type_Local_RelZ)
+                {
+                    pt_top = {corner.pt[0], corner.pt[1], corner.pt[2]};
+                    if (corner.type == RoadObjectCorner::Type_Local_AbsZ)
+                        pt_top[2] -= p0[2]; // make road relative
+                    pt_top = add(pt_top, Vec3D{0, 0, corner.height});
+                    pt_top = add(MatVecMultiplication(base_mat, MatVecMultiplication(rot_mat, pt_top)), p0);
+                }
+                else
+                {
+                    pt_top = this->get_xyz(corner.pt[0], corner.pt[1], corner.pt[2] + corner.height);
+                }
+
+                outline_road_obj_mesh.vertices.push_back(pt_top);
+                outline_road_obj_mesh.st_coordinates.push_back({road_object.s0, road_object.t0});
+            }
+        }
+
+        /* add bottom outline */
+        for (const RoadObjectCorner& corner : road_object.outline)
+        {
+            Vec3D pt_base;
+            if (corner.type == RoadObjectCorner::Type_Local_AbsZ || corner.type == RoadObjectCorner::Type_Local_RelZ)
+            {
+                pt_base = {corner.pt[0], corner.pt[1], corner.pt[2]};
+                if (corner.type == RoadObjectCorner::Type_Local_AbsZ)
+                    pt_base[2] -= p0[2]; // make road relative
+                pt_base = add(MatVecMultiplication(base_mat, MatVecMultiplication(rot_mat, pt_base)), p0);
+            }
+            else
+            {
+                pt_base = this->get_xyz(corner.pt[0], corner.pt[1], corner.pt[2]);
+            }
+
+            outline_road_obj_mesh.vertices.push_back(pt_base);
+            outline_road_obj_mesh.st_coordinates.push_back({road_object.s0, road_object.t0});
+        }
+
+        /* run 2D triangulation on top vertices */
+        const std::vector<size_t> idx_patch_top = mapbox::earcut<size_t>(outline_road_obj_mesh.vertices.data(), road_object.outline.size());
+        outline_road_obj_mesh.indices.insert(outline_road_obj_mesh.indices.end(), idx_patch_top.begin(), idx_patch_top.end());
+
+        /* add walls */
+        if (!is_flat_object)
+        {
+            const std::size_t N = road_object.outline.size();
+            for (std::size_t idx = 0; idx < N - 1; idx++)
+            {
+                std::array<size_t, 6> wall_idx_patch = {idx, idx + N, idx + 1, idx + 1, idx + N, idx + N + 1};
+                outline_road_obj_mesh.indices.insert(outline_road_obj_mesh.indices.end(), wall_idx_patch.begin(), wall_idx_patch.end());
+            }
+
+            std::array<size_t, 6> last_idx_patch = {N - 1, 2 * N - 1, 0, 0, 2 * N - 1, N};
+            outline_road_obj_mesh.indices.insert(outline_road_obj_mesh.indices.end(), last_idx_patch.begin(), last_idx_patch.end());
+        }
+
+        road_obj_mesh.add_mesh(outline_road_obj_mesh);
+    }
+
+    return road_obj_mesh;
 }
 
 } // namespace odr

--- a/src/RoadMark.cpp
+++ b/src/RoadMark.cpp
@@ -2,4 +2,52 @@
 
 namespace odr
 {
+RoadMarksLine::RoadMarksLine(std::string road_id,
+                             double      lanesection_s0,
+                             int         lane_id,
+                             double      group_s0,
+                             double      width,
+                             double      length,
+                             double      space,
+                             double      t_offset,
+                             double      s_offset,
+                             std::string name,
+                             std::string rule) :
+    road_id(road_id),
+    lanesection_s0(lanesection_s0), lane_id(lane_id), group_s0(group_s0), width(width), length(length), space(space), t_offset(t_offset),
+    s_offset(s_offset), name(name), rule(rule)
+{
+}
+
+RoadMarkGroup::RoadMarkGroup(std::string road_id,
+                             double      lanesection_s0,
+                             int         lane_id,
+                             double      width,
+                             double      height,
+                             double      s_offset,
+                             std::string type,
+                             std::string weight,
+                             std::string color,
+                             std::string material,
+                             std::string lane_change) :
+    road_id(road_id),
+    lanesection_s0(lanesection_s0), lane_id(lane_id), width(width), height(height), s_offset(s_offset), type(type), weight(weight), color(color),
+    material(material), lane_change(lane_change)
+{
+}
+
+RoadMark::RoadMark(std::string road_id,
+                   double      lanesection_s0,
+                   int         lane_id,
+                   double      group_s0,
+                   double      s_start,
+                   double      s_end,
+                   double      t_offset,
+                   double      width,
+                   std::string type) :
+    road_id(road_id),
+    lanesection_s0(lanesection_s0), lane_id(lane_id), group_s0(group_s0), s_start(s_start), s_end(s_end), t_offset(t_offset), width(width), type(type)
+{
+}
+
 } // namespace odr

--- a/src/RoadObject.cpp
+++ b/src/RoadObject.cpp
@@ -1,16 +1,54 @@
 #include "RoadObject.h"
-#include "RefLine.h"
-#include "Road.h"
-
-#include "earcut/earcut.hpp"
 
 #include <array>
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
-#include <stdexcept>
 
 namespace odr
 {
+
+RoadObjectRepeat::RoadObjectRepeat(double s0,
+                                   double length,
+                                   double distance,
+                                   double t_start,
+                                   double t_end,
+                                   double width_start,
+                                   double width_end,
+                                   double height_start,
+                                   double height_end,
+                                   double z_offset_start,
+                                   double z_offset_end) :
+    s0(s0),
+    length(length), distance(distance), t_start(t_start), t_end(t_end), width_start(width_start), width_end(width_end), height_start(height_start),
+    height_end(height_end), z_offset_start(z_offset_start), z_offset_end(z_offset_end)
+{
+}
+
+RoadObjectCorner::RoadObjectCorner(Vec3D pt, double height, Type type) : pt(pt), height(height), type(type) {}
+
+RoadObject::RoadObject(std::string road_id,
+                       std::string id,
+                       double      s0,
+                       double      t0,
+                       double      z0,
+                       double      length,
+                       double      valid_length,
+                       double      width,
+                       double      radius,
+                       double      height,
+                       double      hdg,
+                       double      pitch,
+                       double      roll,
+                       std::string type,
+                       std::string name,
+                       std::string orientation) :
+    road_id(road_id),
+    id(id), type(type), name(name), orientation(orientation), s0(s0), t0(t0), z0(z0), length(length), valid_length(valid_length), width(width),
+    radius(radius), height(height), hdg(hdg), pitch(pitch), roll(roll)
+{
+}
+
 Mesh3D RoadObject::get_cylinder(double eps, double radius, double height)
 {
     Mesh3D cylinder_mesh;
@@ -34,7 +72,7 @@ Mesh3D RoadObject::get_cylinder(double eps, double radius, double height)
 
         if (cylinder_mesh.vertices.size() > 5)
         {
-            const size_t          cur_idx = cylinder_mesh.vertices.size() - 1;
+            const std::size_t     cur_idx = cylinder_mesh.vertices.size() - 1;
             std::array<size_t, 6> top_bottom_idx_patch = {0, cur_idx - 1, cur_idx - 3, 1, cur_idx - 2, cur_idx};
             cylinder_mesh.indices.insert(cylinder_mesh.indices.end(), top_bottom_idx_patch.begin(), top_bottom_idx_patch.end());
             std::array<size_t, 6> wall_idx_patch = {cur_idx, cur_idx - 2, cur_idx - 3, cur_idx, cur_idx - 3, cur_idx - 1};
@@ -61,200 +99,4 @@ Mesh3D RoadObject::get_box(double w, double l, double h)
     return box_mesh;
 }
 
-Mesh3D RoadObject::get_mesh(double eps) const
-{
-    auto road_ptr = this->road.lock();
-    if (!road_ptr)
-        throw std::runtime_error("could not access parent road for road object");
-
-    std::vector<RoadObjectRepeat> repeats_copy = this->repeats; // make copy to keep method const
-    if (repeats_copy.empty() && this->outline.empty())          // handle single object as 1 object repeat
-    {
-        RoadObjectRepeat rp;
-        rp.s0 = rp.t_start = rp.t_end = rp.width_start = rp.width_end = rp.height_start = rp.height_end = rp.z_offset_start = rp.z_offset_end = NAN;
-        rp.length = 0;
-        rp.distance = 1;
-        rp.xml_node = this->xml_node;
-        repeats_copy.push_back(rp);
-    }
-
-    const Mat3D rot_mat = EulerAnglesToMatrix<double>(roll, pitch, hdg);
-
-    /* helper functions - object repeat's attributes override object's attributes */
-    auto get_t_s = [&](const RoadObjectRepeat& r, const double& p) -> double
-    { return (std::isnan(r.t_start) || std::isnan(r.t_end)) ? this->t0 : r.t_start + p * (r.t_end - r.t_start); };
-
-    auto get_z_s = [&](const RoadObjectRepeat& r, const double& p) -> double
-    { return (std::isnan(r.z_offset_start) || std::isnan(r.z_offset_end)) ? this->z0 : r.z_offset_start + p * (r.z_offset_end - r.z_offset_start); };
-
-    auto get_height_s = [&](const RoadObjectRepeat& r, const double& p) -> double
-    { return (std::isnan(r.height_start) || std::isnan(r.height_end)) ? this->height : r.height_start + p * (r.height_end - r.height_start); };
-
-    auto get_width_s = [&](const RoadObjectRepeat& r, const double& p) -> double
-    { return (std::isnan(r.width_start) || std::isnan(r.width_end)) ? this->width : r.width_start + p * (r.width_end - r.width_start); };
-
-    Mesh3D road_obj_mesh;
-
-    for (const RoadObjectRepeat& repeat : repeats_copy)
-    {
-        const double s_start = std::isnan(repeat.s0) ? this->s0 : repeat.s0;
-        const double s_end = std::min(s_start + repeat.length, road_ptr->length);
-
-        if (repeat.distance != 0)
-        {
-            for (double s = s_start; s <= s_end; s += repeat.distance)
-            {
-                const double p = (s_end == s_start) ? 1.0 : (s - s_start) / (s_end - s_start);
-                const double t_s = get_t_s(repeat, p);
-                const double z_s = get_z_s(repeat, p);
-                const double height_s = get_height_s(repeat, p);
-                const double w_s = get_width_s(repeat, p);
-
-                Mesh3D single_road_obj_mesh;
-                if (this->radius > 0)
-                {
-                    single_road_obj_mesh = this->get_cylinder(eps, this->radius, height_s);
-                }
-                else if (w_s > 0 && this->length > 0)
-                {
-                    single_road_obj_mesh = this->get_box(w_s, this->length, height_s);
-                }
-
-                Vec3D       e_s, e_t, e_h;
-                const Vec3D p0 = road_ptr->get_xyz(s, t_s, z_s, &e_s, &e_t, &e_h);
-                const Mat3D base_mat{{{e_s[0], e_t[0], e_h[0]}, {e_s[1], e_t[1], e_h[1]}, {e_s[2], e_t[2], e_h[2]}}};
-                for (Vec3D& pt_uvz : single_road_obj_mesh.vertices)
-                {
-                    pt_uvz = MatVecMultiplication(rot_mat, pt_uvz);
-                    pt_uvz = MatVecMultiplication(base_mat, pt_uvz);
-                    pt_uvz = add(pt_uvz, p0);
-
-                    single_road_obj_mesh.st_coordinates.push_back({s, t_s});
-                }
-
-                road_obj_mesh.add_mesh(single_road_obj_mesh);
-            }
-        }
-        else
-        {
-            Mesh3D continuous_road_obj_mesh;
-
-            const std::array<size_t, 24> idx_patch_template = {1, 5, 4, 1, 4, 0, 2, 7, 6, 2, 3, 7, 1, 6, 5, 1, 2, 6, 0, 4, 7, 0, 7, 3};
-            for (const double& s : road_ptr->ref_line->approximate_linear(eps, s_start, s_end))
-            {
-                const double p = (s_end == s_start) ? 1.0 : (s - s_start) / (s_end - s_start);
-                const double t_s = get_t_s(repeat, p);
-                const double z_s = get_z_s(repeat, p);
-                const double height_s = get_height_s(repeat, p);
-                const double w_s = get_width_s(repeat, p);
-
-                continuous_road_obj_mesh.vertices.push_back(road_ptr->get_xyz(s, t_s - 0.5 * w_s, z_s));
-                continuous_road_obj_mesh.vertices.push_back(road_ptr->get_xyz(s, t_s + 0.5 * w_s, z_s));
-                continuous_road_obj_mesh.vertices.push_back(road_ptr->get_xyz(s, t_s + 0.5 * w_s, z_s + height_s));
-                continuous_road_obj_mesh.vertices.push_back(road_ptr->get_xyz(s, t_s - 0.5 * w_s, z_s + height_s));
-
-                const std::array<Vec2D, 4> s_t_coords = {{{s, t_s - 0.5 * w_s}, {s, t_s + 0.5 * w_s}, {s, t_s + 0.5 * w_s}, {s, t_s - 0.5 * w_s}}};
-                continuous_road_obj_mesh.st_coordinates.insert(continuous_road_obj_mesh.st_coordinates.end(), s_t_coords.begin(), s_t_coords.end());
-
-                if (continuous_road_obj_mesh.vertices.size() == 4)
-                {
-                    const std::array<size_t, 6> front_idx_patch = {0, 2, 1, 0, 3, 2};
-                    continuous_road_obj_mesh.indices.insert(continuous_road_obj_mesh.indices.end(), front_idx_patch.begin(), front_idx_patch.end());
-                }
-
-                if (continuous_road_obj_mesh.vertices.size() > 7)
-                {
-                    const size_t           cur_offs = continuous_road_obj_mesh.vertices.size() - 8;
-                    std::array<size_t, 24> wall_idx_patch;
-                    for (size_t idx = 0; idx < idx_patch_template.size(); idx++)
-                        wall_idx_patch.at(idx) = idx_patch_template.at(idx) + cur_offs;
-                    continuous_road_obj_mesh.indices.insert(continuous_road_obj_mesh.indices.end(), wall_idx_patch.begin(), wall_idx_patch.end());
-                }
-            }
-
-            const size_t                last_idx = continuous_road_obj_mesh.vertices.size() - 1;
-            const std::array<size_t, 6> back_idx_patch = {last_idx - 3, last_idx - 2, last_idx - 1, last_idx - 3, last_idx - 1, last_idx};
-            continuous_road_obj_mesh.indices.insert(continuous_road_obj_mesh.indices.end(), back_idx_patch.begin(), back_idx_patch.end());
-
-            road_obj_mesh.add_mesh(continuous_road_obj_mesh);
-        }
-    }
-
-    if (this->outline.size() > 1)
-    {
-        Vec3D       e_s, e_t, e_h;
-        const Vec3D p0 = road_ptr->get_xyz(this->s0, this->t0, this->z0, &e_s, &e_t, &e_h);
-
-        const Mat3D base_mat{{{e_s[0], e_t[0], e_h[0]}, {e_s[1], e_t[1], e_h[1]}, {e_s[2], e_t[2], e_h[2]}}};
-
-        Mesh3D outline_road_obj_mesh;
-
-        /* add top outline first - ensure the top vertices are at the front */
-        const bool is_flat_object = std::all_of(this->outline.begin(), this->outline.end(), [](const RoadObjectCorner& c) { return c.height == 0; });
-        if (!is_flat_object)
-        {
-            for (const RoadObjectCorner& corner : this->outline)
-            {
-                Vec3D pt_top;
-                if (corner.type == RoadObjectCorner::Type::Local_AbsZ || corner.type == RoadObjectCorner::Type::Local_RelZ)
-                {
-                    pt_top = {corner.pt[0], corner.pt[1], corner.pt[2]};
-                    if (corner.type == RoadObjectCorner::Type::Local_AbsZ)
-                        pt_top[2] -= p0[2]; // make road relative
-                    pt_top = add(pt_top, Vec3D{0, 0, corner.height});
-                    pt_top = add(MatVecMultiplication(base_mat, MatVecMultiplication(rot_mat, pt_top)), p0);
-                }
-                else
-                {
-                    pt_top = road_ptr->get_xyz(corner.pt[0], corner.pt[1], corner.pt[2] + corner.height);
-                }
-
-                outline_road_obj_mesh.vertices.push_back(pt_top);
-                outline_road_obj_mesh.st_coordinates.push_back({this->s0, this->t0});
-            }
-        }
-
-        /* add bottom outline */
-        for (const RoadObjectCorner& corner : this->outline)
-        {
-            Vec3D pt_base;
-            if (corner.type == RoadObjectCorner::Type::Local_AbsZ || corner.type == RoadObjectCorner::Type::Local_RelZ)
-            {
-                pt_base = {corner.pt[0], corner.pt[1], corner.pt[2]};
-                if (corner.type == RoadObjectCorner::Type::Local_AbsZ)
-                    pt_base[2] -= p0[2]; // make road relative
-                pt_base = add(MatVecMultiplication(base_mat, MatVecMultiplication(rot_mat, pt_base)), p0);
-            }
-            else
-            {
-                pt_base = road_ptr->get_xyz(corner.pt[0], corner.pt[1], corner.pt[2]);
-            }
-
-            outline_road_obj_mesh.vertices.push_back(pt_base);
-            outline_road_obj_mesh.st_coordinates.push_back({this->s0, this->t0});
-        }
-
-        /* run 2D triangulation on top vertices */
-        const std::vector<size_t> idx_patch_top = mapbox::earcut<size_t>(outline_road_obj_mesh.vertices.data(), this->outline.size());
-        outline_road_obj_mesh.indices.insert(outline_road_obj_mesh.indices.end(), idx_patch_top.begin(), idx_patch_top.end());
-
-        /* add walls */
-        if (!is_flat_object)
-        {
-            const std::size_t N = this->outline.size();
-            for (size_t idx = 0; idx < N - 1; idx++)
-            {
-                std::array<size_t, 6> wall_idx_patch = {idx, idx + N, idx + 1, idx + 1, idx + N, idx + N + 1};
-                outline_road_obj_mesh.indices.insert(outline_road_obj_mesh.indices.end(), wall_idx_patch.begin(), wall_idx_patch.end());
-            }
-
-            std::array<size_t, 6> last_idx_patch = {N - 1, 2 * N - 1, 0, 0, 2 * N - 1, N};
-            outline_road_obj_mesh.indices.insert(outline_road_obj_mesh.indices.end(), last_idx_patch.begin(), last_idx_patch.end());
-        }
-
-        road_obj_mesh.add_mesh(outline_road_obj_mesh);
-    }
-
-    return road_obj_mesh;
-}
 } // namespace odr

--- a/src/RoutingGraph.cpp
+++ b/src/RoutingGraph.cpp
@@ -1,37 +1,11 @@
 #include "RoutingGraph.h"
 
+#include <utility>
+
 namespace odr
 {
 
-RoutingGraphVertex::RoutingGraphVertex(std::string road_id, double lane_section_s0, int lane_id) :
-    road_id(road_id), lane_section_s0(lane_section_s0), lane_id(lane_id)
-{
-}
-
-bool RoutingGraphVertex::operator<(const RoutingGraphVertex& other) const
-{
-    if (this->road_id != other.road_id)
-        return this->road_id < other.road_id;
-    if (this->lane_section_s0 != other.lane_section_s0)
-        return this->lane_section_s0 < other.lane_section_s0;
-    return this->lane_id < other.lane_id;
-}
-
-bool RoutingGraphVertex::operator==(const RoutingGraphVertex& other) const
-{
-    if (this->road_id == other.road_id && this->lane_section_s0 == other.lane_section_s0 && this->lane_id == other.lane_id)
-        return true;
-    return false;
-}
-
-RoutingGraphEdge::RoutingGraphEdge(RoutingGraphVertex from, RoutingGraphVertex to, double length) : from(from), to(to), length(length) {}
-
-bool RoutingGraphEdge::operator==(const RoutingGraphEdge& other) const
-{
-    if (this->from == other.from && this->to == other.to)
-        return true;
-    return false;
-}
+RoutingGraphEdge::RoutingGraphEdge(LaneKey from, LaneKey to, double length) : from(from), to(to), length(length) {}
 
 void RoutingGraph::add_edge(const RoutingGraphEdge& edge)
 {
@@ -40,10 +14,30 @@ void RoutingGraph::add_edge(const RoutingGraphEdge& edge)
     this->predecessors[edge.to].insert(edge.from);
 }
 
-const RoutingEdgeSet& RoutingGraph::get_edges() const { return this->edges; }
+const std::unordered_set<LaneKey>* RoutingGraph::get_lane_successors(const LaneKey& lane) const
+{
+    auto successors_iter = this->successors.find(lane);
+    if (successors_iter == this->successors.end())
+        return nullptr;
+    return &(successors_iter->second);
+}
 
-const RoutingSequentMap& RoutingGraph::get_successors() const { return this->successors; }
+std::unordered_set<LaneKey>* RoutingGraph::get_lane_successors(const LaneKey& lane)
+{
+    return const_cast<std::unordered_set<LaneKey>*>(static_cast<const RoutingGraph&>(*this).get_lane_successors(lane));
+}
 
-const RoutingSequentMap& RoutingGraph::get_predecessors() const { return this->predecessors; }
+const std::unordered_set<LaneKey>* RoutingGraph::get_lane_predecessors(const LaneKey& lane) const
+{
+    auto predecessors_iter = this->predecessors.find(lane);
+    if (predecessors_iter == this->predecessors.end())
+        return nullptr;
+    return &(predecessors_iter->second);
+}
+
+std::unordered_set<LaneKey>* RoutingGraph::get_lane_predecessors(const LaneKey& lane)
+{
+    return const_cast<std::unordered_set<LaneKey>*>(static_cast<const RoutingGraph&>(*this).get_lane_predecessors(lane));
+}
 
 } // namespace odr


### PR DESCRIPTION
…ss memory management, introduce 'LaneKey'

* reduce memory management and dynamic allocations, make most objects local members
* reduce the usage of pointers to a minimum, only used in RefLine to store different RoadGeometries
* move functions from Lane and LaneSection to Road, more logical as Road has all information to generate meshes
* get rid of pointers to parent objects, not needed anymore as functions moved to Road class
* add information to make odr objects clearly assignable in road network (road id, lanesection s0, lane id..)
* viewer - remove bindings from Embind.cpp that would require adaption to new API (TODO), adapt viewer